### PR TITLE
Fix vitest config test path

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.spec.js']
+  }
+})


### PR DESCRIPTION
## Summary
- add `vitest.config.js`
- configure tests to search under `tests/**/*.spec.js`

## Testing
- `node node_modules/vitest/vitest.mjs run` *(fails: esbuild for wrong platform)*

------
https://chatgpt.com/codex/tasks/task_e_688c08a32cf0832ba56417c87f7c253c