### PR TITLE
Adiciona conferência por RZ e exportação detalhada

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,10 +8,10 @@
 <body>
   <h1>Conferência de Lotes</h1>
   <input type="file" id="fileInput" accept=".xlsx" />
+  <select id="rzSelect"></select>
   <div id="progresso">0 de 0 conferidos</div>
   <input type="text" id="codigoInput" placeholder="Código do produto" />
   <button id="registrarBtn">Registrar</button>
-  <button id="faltanteBtn">Marcar Faltante</button>
   <button id="finalizarBtn">Finalizar Conferência</button>
   <section>
     <h2>Conferidos</h2>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,44 +1,117 @@
 const STORAGE_KEY = 'conferencia-state';
 
+// Estrutura principal do estado:
+// pallets: { RZ: { expected:{codigo:qtde}, conferido:{codigo:qtde}, excedentes:{codigo:qtde} } }
+// currentRZ: RZ atualmente selecionado para conferência
 export const state = {
-  expected: [],
-  conferidos: [],
-  excedentes: [],
-  faltantes: [],
-  total: 0,
+  pallets: {},
+  currentRZ: null,
 };
 
-export function init(codes) {
-  state.expected = codes.slice();
-  state.conferidos = [];
-  state.excedentes = [];
-  state.faltantes = [];
-  state.total = codes.length;
+export function init(pallets) {
+  state.pallets = {};
+  Object.keys(pallets).forEach(rz => {
+    state.pallets[rz] = {
+      expected: { ...pallets[rz] },
+      conferido: {},
+      excedentes: {},
+    };
+  });
+  state.currentRZ = null;
   save();
+}
+
+export function selectRZ(rz) {
+  state.currentRZ = rz;
+  if (!state.pallets[rz]) {
+    state.pallets[rz] = { expected: {}, conferido: {}, excedentes: {} };
+  }
+  save();
+}
+
+function getCurrent() {
+  return state.pallets[state.currentRZ];
 }
 
 export function conferir(codigo) {
-  const idx = state.expected.indexOf(codigo);
-  if (idx !== -1) {
-    state.expected.splice(idx, 1);
-    state.conferidos.push(codigo);
-  } else if (!state.excedentes.includes(codigo)) {
-    state.excedentes.push(codigo);
+  const pallet = getCurrent();
+  if (!pallet) return;
+  const esperado = pallet.expected[codigo];
+  if (esperado) {
+    pallet.conferido[codigo] = (pallet.conferido[codigo] || 0) + 1;
+    if (pallet.conferido[codigo] > esperado) {
+      pallet.excedentes[codigo] = (pallet.excedentes[codigo] || 0) + 1;
+    }
+  } else {
+    pallet.excedentes[codigo] = (pallet.excedentes[codigo] || 0) + 1;
   }
   save();
 }
 
-export function marcarFaltante(codigo) {
-  const idx = state.expected.indexOf(codigo);
-  if (idx !== -1) {
-    state.expected.splice(idx, 1);
-    state.faltantes.push(codigo);
-    save();
-  }
+export function progress() {
+  const pallet = getCurrent();
+  if (!pallet) return { done: 0, total: 0 };
+  const total = Object.values(pallet.expected).reduce((s, q) => s + q, 0);
+  const done = Object.entries(pallet.conferido).reduce(
+    (s, [codigo, qtd]) => s + Math.min(qtd, pallet.expected[codigo] || 0),
+    0,
+  );
+  return { done, total };
 }
 
-export function progress() {
-  return { done: state.conferidos.length, total: state.total };
+export function listarConferidos() {
+  const pallet = getCurrent();
+  if (!pallet) return [];
+  return Object.keys(pallet.conferido).map(codigo => ({
+    codigo,
+    conferido: pallet.conferido[codigo],
+    esperado: pallet.expected[codigo] || 0,
+  }));
+}
+
+export function listarFaltantes() {
+  const pallet = getCurrent();
+  if (!pallet) return [];
+  const faltantes = [];
+  Object.keys(pallet.expected).forEach(codigo => {
+    const esperado = pallet.expected[codigo];
+    const conf = pallet.conferido[codigo] || 0;
+    if (conf < esperado) {
+      faltantes.push({
+        codigo,
+        quantidade: esperado - conf,
+        esperado,
+        conferido: conf,
+      });
+    }
+  });
+  return faltantes;
+}
+
+export function listarExcedentes() {
+  const pallet = getCurrent();
+  if (!pallet) return [];
+  return Object.keys(pallet.excedentes).map(codigo => ({
+    codigo,
+    quantidade: pallet.excedentes[codigo],
+  }));
+}
+
+export function finalizeCurrent() {
+  const pallet = getCurrent();
+  if (!pallet) return { conferidos: [], faltantes: [], excedentes: [] };
+  const conferidos = [];
+  Object.keys(pallet.expected).forEach(codigo => {
+    const esperado = pallet.expected[codigo];
+    const conf = pallet.conferido[codigo] || 0;
+    const qtde = Math.min(conf, esperado);
+    if (qtde > 0) {
+      conferidos.push({ codigo, quantidade: qtde });
+    }
+  });
+  const faltantes = listarFaltantes().map(f => ({ codigo: f.codigo, quantidade: f.quantidade }));
+  const excedentes = listarExcedentes();
+  return { conferidos, faltantes, excedentes };
 }
 
 export function save() {
@@ -52,20 +125,22 @@ export function load() {
   const saved = localStorage.getItem(STORAGE_KEY);
   if (saved) {
     const data = JSON.parse(saved);
-    state.expected = data.expected || [];
-    state.conferidos = data.conferidos || [];
-    state.excedentes = data.excedentes || [];
-    state.faltantes = data.faltantes || [];
-    state.total = data.total || 0;
+    state.pallets = data.pallets || {};
+    state.currentRZ = data.currentRZ || null;
   }
 }
 
 export default {
   state,
   init,
+  selectRZ,
   conferir,
-  marcarFaltante,
   progress,
+  listarConferidos,
+  listarFaltantes,
+  listarExcedentes,
+  finalizeCurrent,
   save,
   load,
 };
+

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -1,18 +1,36 @@
 import * as XLSX from 'xlsx';
 
-export function readCodesFromXlsx(data) {
+// Lê a planilha do Mercado Livre e retorna um mapeamento
+// de RZ -> { codigo: quantidade }.
+// Espera-se que as colunas estejam na ordem:
+// 0: código ML, 1: quantidade, 2: RZ
+export function readPlanilha(data) {
   const workbook = XLSX.read(data, { type: 'array' });
-  const sheetName = workbook.SheetNames[0];
-  const sheet = workbook.Sheets[sheetName];
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
   const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
-  return rows.map(r => String(r[0]).trim()).filter(Boolean);
+
+  const pallets = {};
+  rows.slice(1).forEach(row => {
+    const codigo = String(row[0]).trim();
+    const quantidade = Number(row[1]) || 1;
+    const rz = String(row[2]).trim();
+    if (!codigo || !rz) return;
+    if (!pallets[rz]) pallets[rz] = {};
+    pallets[rz][codigo] = (pallets[rz][codigo] || 0) + quantidade;
+  });
+
+  return pallets;
 }
 
+// Exporta os resultados finais em um arquivo .xlsx com três abas:
+// conferidos, faltantes e excedentes. Cada aba recebe um array de objetos
+// no formato { codigo, quantidade }.
 export function exportResult({ conferidos, faltantes, excedentes }, filename = 'resultado.xlsx') {
   const wb = XLSX.utils.book_new();
-  const toSheet = arr => XLSX.utils.json_to_sheet(arr.map(codigo => ({ codigo })));
+  const toSheet = arr => XLSX.utils.json_to_sheet(arr);
   XLSX.utils.book_append_sheet(wb, toSheet(conferidos), 'conferidos');
   XLSX.utils.book_append_sheet(wb, toSheet(faltantes), 'faltantes');
   XLSX.utils.book_append_sheet(wb, toSheet(excedentes), 'excedentes');
   XLSX.writeFile(wb, filename);
 }
+


### PR DESCRIPTION
## Sumário
- lê planilha do Mercado Livre para separar itens por RZ e quantidades
- adiciona seleção de RZ e acompanhamento de conferência parcial
- exporta resultado com abas de conferidos, faltantes e excedentes

## Testes
- `node node_modules/vitest/vitest.mjs run`

------
https://chatgpt.com/codex/tasks/task_e_6894334ec02c832ba6c23eec98abe0cb