### PR TITLE
feat: add spreadsheet processing diagnostics

### DIFF
--- a/tests/excel.spec.js
+++ b/tests/excel.spec.js
@@ -21,7 +21,7 @@ describe('processarPlanilha', () => {
       ['TOTAL', '', { f: 'SUM(C4:C5)' }, 'RZ-123'],
     ];
     const buf = createXlsxBuffer(data);
-    const produtos = await processarPlanilha(buf);
+    const { produtos } = await processarPlanilha(buf);
     expect(produtos).toEqual([
       { codigoML: 'AAA123', descricao: 'Produto A', quantidade: 2, rz: 'RZ-123' },
       { codigoML: 'BBB456', descricao: 'Produto B', quantidade: 1, rz: 'RZ-124' },


### PR DESCRIPTION
## Summary
- show alerts and detailed logs when processing planilha
- expose header and missing fields metadata from `processarPlanilha`
- adapt tests for new processing diagnostics

## Testing
- `node node_modules/vitest/vitest.mjs run`

------
https://chatgpt.com/codex/tasks/task_e_6894962f305c832baab7ab5d4692d495