### PR TITLE
feat: add consult-before-register flow with price adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,11 @@
   <select id="rzSelect"></select>
   <div id="progresso">0 de 0 conferidos</div>
   <input type="text" id="codigoInput" placeholder="Código do produto" />
+  <button id="consultarBtn">Consultar</button>
   <button id="registrarBtn">Registrar</button>
   <button id="finalizarBtn">Finalizar Conferência</button>
+
+  <div id="consultaCard"></div>
 
   <section>
     <h2>Conferidos</h2>

--- a/tests/excel.spec.js
+++ b/tests/excel.spec.js
@@ -15,16 +15,16 @@ describe('processarPlanilha', () => {
     const data = [
       ['alguma coisa', 'foo'],
       [],
-      ['Cod. ML', 'Item', 'Qtde', 'Palete'],
-      ['AAA123', 'Produto A', 2, 'RZ-123'],
-      ['BBB456', 'Produto B', '1', 'RZ-124'],
-      ['TOTAL', '', { f: 'SUM(C4:C5)' }, 'RZ-123'],
+      ['Cod. ML', 'Item', 'Qtde', 'Palete', 'Preço'],
+      ['AAA123', 'Produto A', 2, 'RZ-123', 10.5],
+      ['BBB456', 'Produto B', '1', 'RZ-124', 5],
+      ['TOTAL', '', { f: 'SUM(C4:C5)' }, 'RZ-123', 0],
     ];
     const buf = createXlsxBuffer(data);
     const { produtos } = await processarPlanilha(buf);
     expect(produtos).toEqual([
-      { codigoML: 'AAA123', descricao: 'Produto A', quantidade: 2, rz: 'RZ-123' },
-      { codigoML: 'BBB456', descricao: 'Produto B', quantidade: 1, rz: 'RZ-124' },
+      { codigoML: 'AAA123', descricao: 'Produto A', quantidade: 2, rz: 'RZ-123', preco: 10.5 },
+      { codigoML: 'BBB456', descricao: 'Produto B', quantidade: 1, rz: 'RZ-124', preco: 5 },
     ]);
   });
 });

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -6,6 +6,7 @@ import store, {
   progress,
   finalizeCurrent,
   save,
+  registrarExcedente,
 } from '../src/store/index.js';
 
 describe('store de conferência com RZ', () => {
@@ -17,7 +18,7 @@ describe('store de conferência com RZ', () => {
       removeItem: key => { delete storage[key]; },
       clear: () => { Object.keys(storage).forEach(k => delete storage[k]); },
     };
-    init({ RZ1: { A: 1, B: 1 } });
+    init({ RZ1: { A: 1, B: 1 } }, { A: { descricao: '', preco: 0 }, B: { descricao: '', preco: 0 } });
     selectRZ('RZ1');
   });
 
@@ -26,8 +27,10 @@ describe('store de conferência com RZ', () => {
     expect(progress()).toEqual({ done: 1, total: 2 });
   });
 
-  it('código desconhecido vai para excedentes', () => {
-    conferir('X');
+  it('código desconhecido vai para excedentes após registrar', () => {
+    const r = conferir('X');
+    expect(r.status).toBe('not-found');
+    registrarExcedente('X');
     const res = finalizeCurrent();
     expect(res.excedentes).toEqual([{ codigo: 'X', quantidade: 1 }]);
   });


### PR DESCRIPTION
## Summary
- add Consultar step before registering items
- handle price adjustments and excedentes with autosave
- export results with adjustments sheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689671e5ed24832b9bb7c31c735e62eb