### PR TITLE
feat: price adjustments and financial summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,16 @@
   <select id="rzSelect"></select>
   <div id="progresso">0 de 0 conferidos</div>
   <input type="text" id="codigoInput" placeholder="Código do produto" />
+  <input type="number" id="precoInput" placeholder="Preço ajustado" step="0.01" />
+  <input type="text" id="obsInput" placeholder="Observação" />
   <button id="consultarBtn">Consultar</button>
   <button id="registrarBtn">Registrar</button>
   <button id="finalizarBtn">Finalizar Conferência</button>
 
   <div id="consultaCard"></div>
+
+  <div id="resumoRZ"></div>
+  <div id="resumoGeral"></div>
 
   <section>
     <h2>Conferidos</h2>

--- a/tests/excel.spec.js
+++ b/tests/excel.spec.js
@@ -23,8 +23,8 @@ describe('processarPlanilha', () => {
     const buf = createXlsxBuffer(data);
     const { produtos } = await processarPlanilha(buf);
     expect(produtos).toEqual([
-      { codigoML: 'AAA123', descricao: 'Produto A', quantidade: 2, rz: 'RZ-123', preco: 10.5 },
-      { codigoML: 'BBB456', descricao: 'Produto B', quantidade: 1, rz: 'RZ-124', preco: 5 },
+      { codigoML: 'AAA123', descricao: 'Produto A', quantidade: 2, rz: 'RZ-123', preco: 10.5, valorTotal: 21 },
+      { codigoML: 'BBB456', descricao: 'Produto B', quantidade: 1, rz: 'RZ-124', preco: 5, valorTotal: 5 },
     ]);
   });
 });

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -7,6 +7,7 @@ import store, {
   finalizeCurrent,
   save,
   registrarExcedente,
+  registrarAjuste,
 } from '../src/store/index.js';
 
 describe('store de conferência com RZ', () => {
@@ -18,7 +19,10 @@ describe('store de conferência com RZ', () => {
       removeItem: key => { delete storage[key]; },
       clear: () => { Object.keys(storage).forEach(k => delete storage[k]); },
     };
-    init({ RZ1: { A: 1, B: 1 } }, { A: { descricao: '', preco: 0 }, B: { descricao: '', preco: 0 } });
+    init([
+      { sku: 'A', rz: 'RZ1', qtd: 1, preco: 0, valorTotal: 0, descricao: '' },
+      { sku: 'B', rz: 'RZ1', qtd: 1, preco: 0, valorTotal: 0, descricao: '' },
+    ]);
     selectRZ('RZ1');
   });
 
@@ -31,8 +35,10 @@ describe('store de conferência com RZ', () => {
     const r = conferir('X');
     expect(r.status).toBe('not-found');
     registrarExcedente('X');
+    registrarAjuste({ tipo: 'EXCEDENTE', codigo: 'X', precoOriginal: 0, precoAjustado: 0 });
     const res = finalizeCurrent();
     expect(res.excedentes).toEqual([{ codigo: 'X', quantidade: 1 }]);
+    expect(res.ajustes).toHaveLength(1);
   });
 
   it('salva estado no localStorage', () => {


### PR DESCRIPTION
## Summary
- parse unit and total values with flexible headers and Brazilian number formats
- track item pricing, adjustments, and financial deltas per RZ and overall with autosave
- expose adjusted pricing in UI and export XLSX including financial summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689677ea8830832b89da12cab6ae13a1