### PR TITLE
feat: card de preço, botão Registrar Excedente e fluxos básicos consultar/registrar

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <input type="text" id="obsInput" placeholder="Observação" />
   <button id="consultarBtn">Consultar</button>
   <button id="registrarBtn">Registrar</button>
+  <button id="excedenteBtn" disabled>Registrar Excedente</button>
   <button id="finalizarBtn">Finalizar Conferência</button>
 
   <div id="consultaCard"></div>


### PR DESCRIPTION
## Summary
- show planilha price in consultation card and toggle register/excedente buttons
- record price adjustments and excedentes with optional observation
- add dedicated Registrar Excedente button and focus workflow

## Testing
- `npm test -- --run`
- `npm start`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689685a56128832b8efaee1193817031