### PR TITLE
Acumula avisos de linhas ignoradas e modo de teste verboso

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",
-    "test": "vitest",
+    "test": "vitest run --reporter=dot --silent",
+    "test:verbose": "cross-env VERBOSE=1 vitest run --reporter=verbose",
     "start": "node src/server.js"
   },
   "dependencies": {
@@ -13,7 +14,8 @@
   },
   "devDependencies": {
     "vite": "^4.0.0",
-    "vitest": "^0.34.0"
+    "vitest": "^0.34.0",
+    "cross-env": "^7.0.3"
   },
   "type": "module"
 }

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -231,6 +231,7 @@ export async function processarPlanilha(file) {
       }
 
       const produtos = [];
+      const ignored = [];
       for (let i = 0; i < dataRows.length; i++) {
         const row = dataRows[i];
         const codigoML = row[indices.codigoML]
@@ -255,13 +256,19 @@ export async function processarPlanilha(file) {
         if (!valorTotal && preco) valorTotal = preco * quantidade;
 
         if (!codigoML || !descricao || !rz) {
-          console.warn(
-            `Linha ${headerRow + i + 2} ignorada por falta de dados essenciais`,
-          );
+          ignored.push(headerRow + i + 2);
           continue;
         }
 
         produtos.push({ codigoML, descricao, quantidade, rz, preco, valorTotal });
+      }
+
+      const verbose =
+        process.env.VERBOSE === '1' || process.env.CONFER_VERBOSE === '1';
+      if (ignored.length && verbose) {
+        console.warn(
+          `${ignored.length} linha(s) ignoradas por falta de dados essenciais: ${ignored.join(', ')}`,
+        );
       }
 
       const rzs = Array.from(new Set(produtos.map(p => p.rz)));

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,14 @@
+import { beforeAll, afterAll, vi } from 'vitest';
+
+let warnSpy;
+const verbose = process.env.VERBOSE === '1' || process.env.CONFER_VERBOSE === '1';
+
+beforeAll(() => {
+  if (!verbose) {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  }
+});
+
+afterAll(() => {
+  warnSpy?.mockRestore();
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.spec.js']
+    include: ['tests/**/*.spec.js'],
+    setupFiles: ['tests/setup.ts']
   }
 })


### PR DESCRIPTION
## Summary
- Agrupa índices de linhas ignoradas e mostra resumo apenas em modo verboso
- Silencia `console.warn` por padrão nos testes e permite habilitar logs
- Adiciona script `test:verbose` e dependência `cross-env` para executar testes com logs

## Testing
- `npm run -s test` *(falhou: RangeError: Invalid count value: Infinity)*
- `npm run -s test:verbose` *(falhou: cross-env: not found)*
- `npx vitest run`
- `VERBOSE=1 npx vitest run --reporter=verbose`
- `npm ci` *(falhou: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*

------
https://chatgpt.com/codex/tasks/task_e_68969413a128832bb0eeb4eca0f146ff