### PR TITLE
feat(excedente): descrição, quantidade, preço médio consolidado por SKU/RZ + autosave e export ajustado

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
       <input type="text" id="codigoInput" placeholder="Código do produto" />
       <input type="number" id="precoInput" placeholder="Preço ajustado" step="0.01" />
       <input type="text" id="obsInput" placeholder="Observação" />
+      <div id="excedenteForm" style="display:none">
+        <input type="text" id="exDescInput" placeholder="Descrição do produto" />
+        <input type="number" id="exQtdInput" min="1" value="1" />
+      </div>
       <button id="consultarBtn">Consultar</button>
       <button id="registrarBtn">Registrar</button>
       <button id="excedenteBtn" disabled>Registrar Excedente</button>
@@ -84,7 +88,18 @@
               <option value="100">100</option>
             </select>
           </div>
-          <table><tbody id="excedentesTable"></tbody></table>
+          <table>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Descrição</th>
+                <th>Qtd</th>
+                <th>Preço Médio (R$)</th>
+                <th>Valor Total (R$)</th>
+              </tr>
+            </thead>
+            <tbody id="excedentesTable"></tbody>
+          </table>
           <div class="pagination" id="excedentesPagination"></div>
         </div>
       </div>

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -34,10 +34,25 @@ describe('store de conferência com RZ', () => {
   it('código desconhecido vai para excedentes após registrar', () => {
     const r = conferir('X');
     expect(r.status).toBe('not-found');
-    registrarExcedente('X');
-    registrarAjuste({ tipo: 'EXCEDENTE', codigo: 'X', precoOriginal: 0, precoAjustado: 0 });
+    registrarExcedente({
+      sku: 'X',
+      descricao: 'Produto X',
+      qtd: 1,
+      precoUnit: 10,
+      obs: '',
+    });
+    registrarAjuste({
+      tipo: 'EXCEDENTE',
+      codigo: 'X',
+      precoOriginal: 0,
+      precoAjustado: 10,
+      qtd: 1,
+      obs: '',
+    });
     const res = finalizeCurrent();
-    expect(res.excedentes).toEqual([{ codigo: 'X', quantidade: 1 }]);
+    expect(res.excedentes).toMatchObject([
+      { sku: 'X', rz: 'RZ1', descricao: 'Produto X', qtd: 1, precoMedio: 10, valorTotal: 10 },
+    ]);
     expect(res.ajustes).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary
- turn excedentes into full product records with description, qty and weighted price per SKU/RZ
- show excedentes mini-form and detailed list with price and total, plus autosave & resume support
- log excedente adjustments with qty and update exports

## Testing
- `npm run -s test`


------
https://chatgpt.com/codex/tasks/task_e_6896a128a920832b9be641709ad8f58e