### PR TITLE
feat: improve scanning with ZXing fallback and show faltantes descriptions

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -139,7 +139,7 @@ th, td {
 .diff-zero { background: #e5e7eb; color: #374151; }
 
 .scan-modal { position: fixed; inset: 0; background: rgba(0,0,0,.85); display: flex; align-items: center; justify-content: center; z-index: 50; }
-.scan-modal.hidden { display: none; }
+.scan-modal.hidden { display: none !important; }
 .scan-box { width: min(95vw, 640px); aspect-ratio: 3/4; background: #000; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column; }
 #videoPreview { width: 100%; height: 100%; object-fit: cover; flex: 1; }
 .scan-actions { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: 8px; background: #111; color: #fff; }


### PR DESCRIPTION
## Summary
- use dynamic ZXing import with graceful fallback for camera scanning
- honor manual/auto scan modes and reset camera resources
- show description with SKU in Faltantes list and allow search by description

## Testing
- `npm ci`
- `npx vitest run --reporter=verbose`


------
https://chatgpt.com/codex/tasks/task_e_6896bcbc39b8832bb4779c535ad58047