### PR TITLE
fix(scan): remover imports de '@zxing/browser' e usar CDN ESM com /* @vite-ignore */ para evitar erro do Vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "conferencia-lotes",
       "version": "1.0.0",
       "dependencies": {
-        "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
         "express": "^4.19.2",
         "multer": "^1.4.5-lts.1",
@@ -519,18 +518,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@zxing/browser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
-      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@zxing/text-encoding": "^0.9.0"
-      },
-      "peerDependencies": {
-        "@zxing/library": "^0.21.0"
       }
     },
     "node_modules/@zxing/library": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "node src/server.js"
   },
   "dependencies": {
-    "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "express": "^4.19.2",
     "multer": "^1.4.5-lts.1",

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -574,24 +574,10 @@ async function loopNativo() {
 }
 
 async function iniciarZXing() {
-  async function loadLocal() {
-    // tenta o pacote local (se instalado)
-    return await import('@zxing/browser');
-  }
-  async function loadFromCdn() {
-    // fallback ESM por CDN; @vite-ignore impede o Vite de tentar resolver localmente
-    return await import(/* @vite-ignore */ 'https://cdn.jsdelivr.net/npm/@zxing/browser@0.1.4/+esm');
-  }
-
   try {
-    let mod;
-    try {
-      mod = await loadLocal();
-    } catch (errLocal) {
-      console.warn('ZXing local indisponível, usando CDN…', errLocal);
-      mod = await loadFromCdn();
-    }
-
+    // CDN em ESM; @vite-ignore impede o Vite de tentar resolver localmente
+    const ZXING_CDN = 'https://cdn.jsdelivr.net/npm/' + '@zxing' + '/browser@0.1.4/+esm';
+    const mod = await import(/* @vite-ignore */ ZXING_CDN);
     const { BrowserMultiFormatReader } = mod || {};
     if (!BrowserMultiFormatReader) {
       console.error('ZXing sem BrowserMultiFormatReader');
@@ -599,9 +585,8 @@ async function iniciarZXing() {
       return;
     }
 
-    // cria reader e usa o stream já aberto no <video>
     zxingReader = new BrowserMultiFormatReader();
-    await zxingReader.decodeFromVideoElement(videoEl, (result /*, err */) => {
+    await zxingReader.decodeFromVideoElement(videoEl, (result) => {
       if (!reading || !result) return;
       const text = String(result.getText?.() || '').trim();
       if (text && text !== lastResult) {
@@ -610,7 +595,7 @@ async function iniciarZXing() {
       }
     });
   } catch (err) {
-    console.error('Falha ao carregar ZXing (local e CDN):', err);
+    console.error('Falha ao carregar ZXing do CDN:', err);
     toast?.('Falha ao carregar leitor ZXing');
   }
 }


### PR DESCRIPTION
## Summary
- remover dependência local de `@zxing/browser`
- carregar ZXing apenas via CDN ESM com `@vite-ignore`

## Testing
- `npm run -s test` *(falhou: RangeError: Invalid count value: Infinity)*
- `npm run -s test:verbose`


------
https://chatgpt.com/codex/tasks/task_e_689757a206f4832ba6f054cb0dc1ba97