### PR TITLE
fix(excel,app): remover process.env do browser e fallback para store sem dispatch

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -50,7 +50,12 @@ export function initApp() {
       // auto‑seleciona se só houver 1 RZ
       if (list.length === 1) {
         rzSelect.value = list[0];
-        store.dispatch(selectRZ(list[0]));
+        if (store && typeof store.dispatch === 'function') {
+          store.dispatch(selectRZ(list[0]));
+        } else {
+          if (!store.state) store.state = {};
+          store.state.currentRZ = list[0];
+        }
         log('RZ auto‑selecionado:', list[0]);
       }
 
@@ -65,7 +70,13 @@ export function initApp() {
   // ===== Seleção de RZ =====
   rzSelect.addEventListener('change', (e) => {
     const rz = e.target.value || null;
-    store.dispatch(selectRZ(rz));
+    if (store && typeof store.dispatch === 'function') {
+      store.dispatch(selectRZ(rz));
+    } else {
+      // fallback para store simples
+      if (!store.state) store.state = {};
+      store.state.currentRZ = rz;
+    }
     log('RZ selecionado:', rz);
     if (typeof window.render === 'function') window.render();
   });
@@ -126,6 +137,8 @@ export function initApp() {
   window.addEventListener('beforeunload', async () => {
     try { await pararLeitura(videoEl); } catch {}
   });
+
+  window.store = store;
 }
 
 function renderRZOptions(rzSelect, list) {

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -1,11 +1,11 @@
 import * as XLSX from 'xlsx';
 import store from '../store/index.js';
 
-const DBG = (...a) => {
-  if (typeof window !== 'undefined' && window.__DEBUG_SCAN__) {
-    console.log('[XLSX]', ...a);
-  }
-};
+const isDev =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV) ||
+  (typeof window !== 'undefined' && window.__DEBUG_SCAN__ === true);
+
+const DBG = (...a) => { if (isDev) console.log('[XLSX]', ...a); };
 
 function toNumberBR(v) {
   if (v == null) return 0;
@@ -305,7 +305,9 @@ export async function processarPlanilha(file) {
       }
 
       const verbose =
-        process.env.VERBOSE === '1' || process.env.CONFER_VERBOSE === '1';
+        typeof import.meta !== 'undefined' &&
+        import.meta.env &&
+        (import.meta.env.VERBOSE === '1' || import.meta.env.CONFER_VERBOSE === '1');
       if (ignored.length && verbose) {
         console.warn(
           `${ignored.length} linha(s) ignoradas por falta de dados essenciais: ${ignored.join(', ')}`,


### PR DESCRIPTION
## Summary
- use Vite `import.meta.env` and guarded logs in Excel utils
- handle RZ selection without store.dispatch and expose store for debugging

## Testing
- `rg "process.env" -n src -g '!server.js'`
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6897833fdc34832b838e6384b4924287