### PR TITLE
feat: improve barcode scanning

### DIFF
--- a/src/utils/scan.js
+++ b/src/utils/scan.js
@@ -10,9 +10,16 @@ export async function iniciarZXing(videoEl, onResult, opts = {}) {
   if (zxingReader) return zxingReader;
   dbg('Carregando ZXing do CDN...');
   const mod = await import(/* @vite-ignore */ ZXING_CDN);
-  const { BrowserMultiFormatReader } = mod;
+  const { BrowserMultiFormatReader, BarcodeFormat, DecodeHintType } = mod;
 
-  zxingReader = new BrowserMultiFormatReader();
+  const hints = new Map();
+  hints.set(DecodeHintType.POSSIBLE_FORMATS, [
+    BarcodeFormat.QR_CODE,
+    BarcodeFormat.CODE_128,
+    BarcodeFormat.EAN_13
+  ]);
+
+  zxingReader = new BrowserMultiFormatReader(hints);
   zxingControls = await zxingReader.decodeFromVideoDevice(
     opts.deviceId ?? undefined,
     videoEl,


### PR DESCRIPTION
## Summary
- add flexible registrarConferido to normalize and track scanned SKUs
- support camera and USB scanner input with automatic code registration
- configure ZXing to read QR Code, Code-128 and EAN-13

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897950ef224832b8b3a77bd0172f329