### PR TITLE
feat: renderizar conferidos/pendentes e registrar eventos

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
       <input type="text" id="codigo-ml" placeholder="Código do produto" />
       <button id="btn-scan-toggle" type="button">Ler código</button>
       <video id="preview" playsinline muted style="width:0;height:0;position:absolute;left:-9999px;"></video>
-      <input type="number" id="precoInput" placeholder="Preço ajustado" step="0.01" />
-      <input type="text" id="obsInput" placeholder="Observação" />
+        <input type="number" id="preco-ajustado" placeholder="Preço ajustado" step="0.01" />
+        <input type="text" id="observacao" placeholder="Observação" />
       <div id="excedenteForm" style="display:none">
         <input type="text" id="exDescInput" placeholder="Descrição do produto" />
         <input type="number" id="exQtdInput" min="1" value="1" />
@@ -38,24 +38,29 @@
     </section>
 
     <section id="listas">
-      <div class="lista-bloco" id="conferidosBloco">
-          <header class="lista-header">
-            <h2>Conferidos <span class="badge" id="count-conferidos">0</span></h2>
-            <button class="lista-toggle" data-list="conferidos">Recolher</button>
-          </header>
-        <div class="lista-body" id="conferidosBody">
-          <div class="lista-controles">
-            <input class="lista-search" data-list="conferidos" placeholder="Buscar por SKU ou descrição" />
-            <select class="lista-pagesize" data-list="conferidos">
-              <option value="20">20</option>
-              <option value="50" selected>50</option>
-              <option value="100">100</option>
-            </select>
-          </div>
-          <table><tbody id="conferidosTable"></tbody></table>
-          <div class="pagination" id="conferidosPagination"></div>
+        <div class="lista-bloco" id="conferidosBloco">
+            <h2>Conferidos <span id="count-conferidos">0</span></h2>
+            <div>
+              <select id="limit-conferidos">
+                <option>50</option>
+                <option>100</option>
+                <option>200</option>
+              </select>
+              <button id="btn-recolher-conferidos" type="button">Recolher</button>
+            </div>
+            <table id="tbl-conferidos" class="tabela">
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                  <th>Descrição</th>
+                  <th>Qtd</th>
+                  <th>Preço Médio (R$)</th>
+                  <th>Valor Total (R$)</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
         </div>
-      </div>
 
       <div class="lista-bloco" id="faltantesBloco">
             <header class="lista-header">
@@ -70,7 +75,7 @@
                   <option>100</option>
                   <option>200</option>
                 </select>
-                <button id="btn-recolher" type="button">Recolher</button>
+                  <button id="btn-recolher-pendentes" type="button">Recolher</button>
               </div>
             <table id="tbl-pendentes" class="tabela">
               <thead>

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,106 +1,139 @@
 // src/components/app.js
 import { iniciarLeitura, pararLeitura } from '../utils/scan.js';
 import { processarPlanilha } from '../utils/excel.js';
-import store from '../store/index.js';
+import store, { setCurrentRZ, addConferido, addMovimento, setLimits } from '../store/index.js';
 
-// normalizadores/helpers
 const up = s => String(s||'').trim().toUpperCase();
 const sum = o => Object.values(o||{}).reduce((a,b)=>a+(Number(b)||0),0);
 
-function groupPendentes(rz){
-  const items  = store.state.itemsByRZ?.[rz] || [];
-  const totals = store.state.totalByRZSku?.[rz] || {};
-  const confs  = store.state.conferidosByRZSku?.[rz] || {};
-  const map = {};
-  for (const it of items){
-    const sku = up(it.codigoML); if (!sku) continue;
-    const pend = (totals[sku]||0) - (confs[sku]||0);
-    if (pend <= 0) continue;
-    const r = (map[sku] ||= { sku, descricao: it.descricao, qtd: pend, vSum:0, qSum:0 });
-    const q = Number(it.qtd)||0;
-    r.vSum += (Number(it.valorUnit)||0) * q;
-    r.qSum += q;
-  }
-  return Object.values(map).map(r=>{
-    const pm = r.qSum ? r.vSum/r.qSum : 0;
-    return { sku:r.sku, descricao:r.descricao, qtd:r.qtd, precoMedio:pm, valorTotal:r.qtd*pm };
-  });
+function rowsConferidos(rz){
+  const conf = store.state.conferidosByRZSku[rz] || {};
+  const meta = store.state.metaByRZSku[rz] || {};
+  return Object.entries(conf).map(([sku, qtd])=>{
+    const m = meta[sku] || {};
+    const preco = Number(m.precoMedio||0);
+    return { sku, descricao: m.descricao||'', qtd, preco, total: qtd*preco };
+  }).sort((a,b)=> b.qtd - a.qtd);
+}
+
+function rowsPendentes(rz){
+  const tot = store.state.totalByRZSku[rz] || {};
+  const conf= store.state.conferidosByRZSku[rz] || {};
+  const meta= store.state.metaByRZSku[rz] || {};
+  return Object.entries(tot).map(([sku, qtdTotal])=>{
+    const done = Number(conf[sku]||0);
+    const rest = Math.max(0, qtdTotal - done);
+    if (rest <= 0) return null;
+    const m = meta[sku] || {};
+    const preco = Number(m.precoMedio||0);
+    return { sku, descricao: m.descricao||'', qtd: rest, preco, total: rest*preco };
+  }).filter(Boolean).sort((a,b)=> b.qtd - a.qtd);
+}
+
+function renderConferidos(){
+  const rz = store.state.currentRZ; if (!rz) return;
+  const limit = store.state.limits.conferidos || 50;
+  const data = rowsConferidos(rz).slice(0, limit);
+  const tb = document.querySelector('#tbl-conferidos tbody');
+  document.getElementById('count-conferidos').textContent =
+    String(sum(store.state.conferidosByRZSku[rz]||{}));
+  if (!tb) return;
+  tb.innerHTML = data.length ? data.map(r=>`
+    <tr>
+      <td>${r.sku}</td>
+      <td>${r.descricao}</td>
+      <td style="text-align:right">${r.qtd}</td>
+      <td style="text-align:right">${r.preco.toFixed(2)}</td>
+      <td style="text-align:right">${r.total.toFixed(2)}</td>
+    </tr>`).join('') :
+    `<tr><td colspan="5" style="text-align:center;color:#777">Nenhum item conferido</td></tr>`;
 }
 
 function renderPendentes(){
-  const rz = store.state.currentRZ;
-  const limit = Number(document.querySelector('#limit-pendentes')?.value || 50);
-  const rows = groupPendentes(rz).slice(0, limit);
+  const rz = store.state.currentRZ; if (!rz) return;
+  const limit = store.state.limits.pendentes || 50;
+  const tot = sum(store.state.totalByRZSku[rz]||{});
+  const conf= sum(store.state.conferidosByRZSku[rz]||{});
+  document.getElementById('count-pendentes').textContent = String(Math.max(0, tot-conf));
+  const data = rowsPendentes(rz).slice(0, limit);
   const tb = document.querySelector('#tbl-pendentes tbody');
   if (!tb) return;
-  tb.innerHTML = rows.length ? rows.map(r=>`
+  tb.innerHTML = data.length ? data.map(r=>`
     <tr>
       <td>${r.sku}</td>
-      <td>${r.descricao||''}</td>
+      <td>${r.descricao}</td>
       <td style="text-align:right">${r.qtd}</td>
-      <td style="text-align:right">${r.precoMedio.toFixed(2)}</td>
-      <td style="text-align:right">${r.valorTotal.toFixed(2)}</td>
+      <td style="text-align:right">${r.preco.toFixed(2)}</td>
+      <td style="text-align:right">${r.total.toFixed(2)}</td>
     </tr>`).join('') :
     `<tr><td colspan="5" style="text-align:center;color:#777">Sem pendências para este RZ</td></tr>`;
 }
 
-function refreshUI(){
-  const rz = store.state.currentRZ;
-  const total = sum(store.state.totalByRZSku?.[rz] || {});
-  const conf  = sum(store.state.conferidosByRZSku?.[rz] || {});
-  const pend  = Math.max(0, total - conf);
-  (document.getElementById('count-conferidos')||{}).textContent = String(conf);
-  (document.getElementById('count-pendentes')||{}).textContent = String(pend);
-  renderPendentes();
-}
+function refreshUI(){ renderConferidos(); renderPendentes(); }
 
 function registrarCodigo(raw){
   const rz = store.state.currentRZ;
   const sku = up(raw);
   if (!rz || !sku) return;
 
-  const totals = store.state.totalByRZSku?.[rz] || {};
-  const confs  = (store.state.conferidosByRZSku[rz] ||= {});
+  const tot = store.state.totalByRZSku[rz] || {};
+  if (!tot[sku]) { console.info('[CONF] SKU fora do RZ:', sku); refreshUI(); return; }
 
-  if (!totals[sku]) { console.info('[CONF] SKU fora do RZ:', sku); refreshUI(); return; }
-  const atual = Number(confs[sku]||0);
-  const max   = Number(totals[sku]||0);
-  if (atual >= max) { console.info('[CONF] SKU completo', sku, `${atual}/${max}`); refreshUI(); return; }
+  // incrementa
+  addConferido(rz, sku, 1);
 
-  confs[sku] = atual + 1;
+  // captura ajustes (se existirem na tela)
+  const preco = Number(document.querySelector('#preco-ajustado')?.value || NaN);
+  const obs   = String(document.querySelector('#observacao')?.value || '').trim();
+
+  addMovimento({
+    ts: Date.now(),
+    rz, sku, delta: 1,
+    precoAjustado: isNaN(preco) ? null : preco,
+    observacao: obs || null,
+  });
+
   refreshUI();
 }
 
 export function initApp(){
   const fileInput = document.querySelector('#input-arquivo');
   const rzSelect = document.querySelector('#select-rz');
-  const input =
-    document.querySelector('#codigo-ml') ||
+  const inSku = document.querySelector('#codigo-ml') ||
     document.querySelector('input[placeholder="Código do produto"]');
   const btnReg = document.querySelector('#btn-registrar') ||
     Array.from(document.querySelectorAll('button')).find(b=>/registrar/i.test(b.textContent||''));
   const btnScan = document.querySelector('#btn-scan-toggle') ||
     Array.from(document.querySelectorAll('button')).find(b=>/ler c[oó]digo/i.test(b.textContent||''));
-  const limitSel = document.querySelector('#limit-pendentes');
-  const btnRecolher = document.querySelector('#btn-recolher') ||
-    Array.from(document.querySelectorAll('button')).find(b=>/recolher/i.test(b.textContent||''));
   const videoEl = document.querySelector('#preview');
 
-  input?.addEventListener('keydown', (e)=>{
-    if (e.key === 'Enter'){ registrarCodigo(input.value); input.select(); }
+  inSku?.addEventListener('keydown', e => {
+    if (e.key === 'Enter'){ registrarCodigo(inSku.value); inSku.select(); }
   });
-  btnReg?.addEventListener('click', ()=>{ registrarCodigo(input?.value); input?.select(); });
+  btnReg?.addEventListener('click', () => { registrarCodigo(inSku?.value); inSku?.select(); });
 
-  limitSel?.addEventListener('change', renderPendentes);
-  btnRecolher?.addEventListener('click', renderPendentes);
+  // Recolher conferidos/pendentes
+  document.querySelector('#limit-conferidos')?.addEventListener('change', e=>{
+    setLimits('conferidos', e.target.value); renderConferidos();
+  });
+  document.querySelector('#btn-recolher-conferidos')?.addEventListener('click', ()=>{
+    const v = document.querySelector('#limit-conferidos')?.value; setLimits('conferidos', v); renderConferidos();
+  });
+  document.querySelector('#limit-pendentes')?.addEventListener('change', e=>{
+    setLimits('pendentes', e.target.value); renderPendentes();
+  });
+  document.querySelector('#btn-recolher-pendentes')?.addEventListener('click', ()=>{
+    const v = document.querySelector('#limit-pendentes')?.value; setLimits('pendentes', v); renderPendentes();
+  });
 
+  // Scanner toggle
   let scanning = false;
   btnScan?.addEventListener('click', async ()=>{
     try{
       if (!scanning){
         await iniciarLeitura(videoEl, (texto)=>{
           registrarCodigo(texto);
-          if (input){ input.value = texto; input.select(); }
+          if (inSku){ inSku.value = texto; inSku.select(); }
         });
         scanning = true; btnScan.textContent = 'Parar leitura';
         setBoot('Scanner ativo ▶️');
@@ -109,14 +142,18 @@ export function initApp(){
         scanning = false; btnScan.textContent = 'Ler código';
         setBoot('Scanner parado ⏹️');
       }
-    } catch (err){
+    } catch(err){
       console.error('Erro iniciarLeitura', err);
       setBoot('Falha ao iniciar scanner ❌ (veja Console)');
       scanning = false; btnScan.textContent = 'Ler código';
     }
   });
 
-  rzSelect?.addEventListener('change', ()=> refreshUI());
+  // Ao trocar RZ → refresh completo
+  document.querySelector('#select-rz')?.addEventListener('change', e=>{
+    setCurrentRZ(e.target.value || null);
+    refreshUI();
+  });
 
   // upload planilha
   fileInput?.addEventListener('change', async (e)=>{
@@ -126,9 +163,12 @@ export function initApp(){
     const { rzList } = await processarPlanilha(buf);
     if (rzSelect){
       rzSelect.innerHTML = rzList.map(rz=>`<option value="${rz}">${rz}</option>`).join('');
-      if (rzList.length){ rzSelect.value = rzList[0]; store.state.currentRZ = rzList[0]; }
+      if (rzList.length){
+        rzSelect.value = rzList[0];
+        setCurrentRZ(rzList[0]);
+      }
     } else {
-      store.state.currentRZ = rzList[0] || null;
+      setCurrentRZ(rzList[0] || null);
     }
     refreshUI();
   });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,10 +1,35 @@
 // src/store/index.js
 const state = {
+  currentRZ: null,
+
+  // listas e dados brutos
   rzList: [],
   itemsByRZ: {},          // { RZ: [ { codigoML, descricao, qtd, valorUnit, ... } ] }
-  totalByRZSku: {},       // { RZ: { SKU: totalQtd } }
-  conferidosByRZSku: {},  // { RZ: { SKU: qtdConferida } }
-  currentRZ: null,
+
+  // totais por RZ → SKU (vindo do Excel)
+  totalByRZSku: {},       // { [rz]: { [sku]: qtdTotal } }
+
+  // metadados por RZ → SKU (vindo do Excel)
+  metaByRZSku: {},        // { [rz]: { [sku]: { descricao, precoMedio } } }
+
+  // conferidos em runtime
+  conferidosByRZSku: {},  // { [rz]: { [sku]: qtdConferida } }
+
+  // eventos de conferência (para auditoria/finalizar)
+  movimentos: [],         // [{ ts, rz, sku, delta, precoAjustado, observacao }]
+
+  limits: {
+    conferidos: 50,
+    pendentes: 50,
+  },
 };
+
+export function setCurrentRZ(rz){ state.currentRZ = rz; }
+export function addMovimento(m){ state.movimentos.push(m); }
+export function addConferido(rz, sku, delta=1){
+  const map = (state.conferidosByRZSku[rz] ||= {});
+  map[sku] = (map[sku]||0) + delta;
+}
+export function setLimits(part, v){ state.limits[part] = Number(v)||50; }
 
 export default { state };

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -135,6 +135,7 @@ export async function processarPlanilha(input) {
     const rzList = Object.keys(itemsByRZ).sort();
 
     const totalByRZSku = {};
+    const metaByRZSku = {};
     for (const rz of rzList) {
       const map = {};
       for (const it of itemsByRZ[rz]) {
@@ -142,6 +143,11 @@ export async function processarPlanilha(input) {
         const inc = Number(it.qtd) || 0;
         if (!sku) continue;
         map[sku] = (map[sku] || 0) + inc;
+
+        const descricao = String(it.descricao || '').trim();
+        const precoMedio = Number(it.valorUnit || 0);
+        (metaByRZSku[rz] ||= {});
+        if (!metaByRZSku[rz][sku]) metaByRZSku[rz][sku] = { descricao, precoMedio };
       }
       totalByRZSku[rz] = map;
     }
@@ -150,11 +156,12 @@ export async function processarPlanilha(input) {
     store.state.itemsByRZ = itemsByRZ;
     store.state.rzList = rzList;
     store.state.totalByRZSku = totalByRZSku;
+    store.state.metaByRZSku = metaByRZSku;
     store.state.conferidosByRZSku = {};
     if (!store.state.currentRZ) store.state.currentRZ = rzList[0] || null;
 
     DBG('RZs (header):', rzList.length, rzList.slice(0, 30));
-    return { rzList, itemsByRZ, totalByRZSku };
+    return { rzList, itemsByRZ, totalByRZSku, metaByRZSku };
   }
 
   // 2) fallback regex se não achar header
@@ -166,11 +173,12 @@ export async function processarPlanilha(input) {
   store.state.itemsByRZ = itemsByRZ;
   store.state.rzList = rzList;
   store.state.totalByRZSku = {};
+  store.state.metaByRZSku = {};
   store.state.conferidosByRZSku = {};
   if (!store.state.currentRZ) store.state.currentRZ = rzList[0] || null;
 
   DBG('RZs (fallback):', rzList.length, rzList.slice(0, 30));
-  return { rzList, itemsByRZ, totalByRZSku: {} };
+  return { rzList, itemsByRZ, totalByRZSku: {}, metaByRZSku: {} };
 }
 
 // Exporta os resultados finais em um arquivo .xlsx com quatro abas:


### PR DESCRIPTION
## Summary
- add conference state helpers and metadata structures
- enrich Excel import with SKU metadata and totals
- render conferidos/pendentes tables and store price/obs per movement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a4000804832b86b75ac708e07dfc