### PR TITLE
feat(conferencia): cabeçalho e consulta com destaque de SKU

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,13 @@
 <body>
   <div id="app-container">
     <header id="topbar">
-      <h1>Conferência de Lotes</h1>
+      <h1>Conferência de Lotes <span id="hdr-conferidos">0 de 0 conferidos</span></h1>
       <button id="helpBtn" title="Ajuda/Atalhos">?</button>
     </header>
 
     <section id="painel-controle">
       <input type="file" id="input-arquivo" accept=".xlsx" />
       <select id="select-rz"></select>
-      <div id="progresso">0 de 0 conferidos</div>
       <input type="text" id="codigo-ml" placeholder="Código do produto" />
       <button id="btn-scan-toggle" type="button">Ler código</button>
       <video id="preview" playsinline muted style="width:0;height:0;position:absolute;left:-9999px;"></video>
@@ -25,7 +24,7 @@
         <input type="text" id="exDescInput" placeholder="Descrição do produto" />
         <input type="number" id="exQtdInput" min="1" value="1" />
       </div>
-      <button id="consultarBtn">Consultar</button>
+      <button id="btn-consultar">Consultar</button>
       <button id="btn-registrar">Registrar</button>
       <button id="excedenteBtn" disabled>Registrar Excedente</button>
       <button id="finalizarBtn">Finalizar Conferência</button>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -144,3 +144,12 @@ th, td {
 #videoPreview { width: 100%; height: 100%; object-fit: cover; flex: 1; }
 .scan-actions { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: 8px; background: #111; color: #fff; }
 .hidden { display: none !important; }
+
+@keyframes pulseRow {
+  0%   { background: #fffbd1; }
+  50%  { background: #ffef88; }
+  100% { background: #fffbd1; }
+}
+tr.pulse {
+  animation: pulseRow 2s ease-in-out;
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -26,10 +26,35 @@ const state = {
 
 export function setCurrentRZ(rz){ state.currentRZ = rz; }
 export function addMovimento(m){ state.movimentos.push(m); }
-export function addConferido(rz, sku, delta=1){
-  const map = (state.conferidosByRZSku[rz] ||= {});
-  map[sku] = (map[sku]||0) + delta;
-}
 export function setLimits(part, v){ state.limits[part] = Number(v)||50; }
 
-export default { state };
+// Helpers de acesso seguro
+export function getTotals(rz) {
+  return store.state.totalByRZSku[rz] || {};
+}
+
+export function getConferidos(rz) {
+  return store.state.conferidosByRZSku[rz] || {};
+}
+
+export function sumQuant(obj) {
+  return Object.values(obj || {}).reduce((a, b) => a + (Number(b) || 0), 0);
+}
+
+export function totalPendentesCount(rz) {
+  const tot = getTotals(rz);
+  const conf = getConferidos(rz);
+  const totalAll = sumQuant(tot);
+  const doneAll = sumQuant(conf);
+  return Math.max(0, totalAll - doneAll);
+}
+
+// nunca deixar negativo
+export function addConferido(rz, sku, delta = 1) {
+  const map = (state.conferidosByRZSku[rz] ||= {});
+  map[sku] = Math.max(0, (Number(map[sku]) || 0) + (Number(delta) || 0));
+}
+
+const store = { state };
+
+export default store;


### PR DESCRIPTION
## Summary
- fix conference header counts and ensure Recolher limits update tables
- safeguard increment-only registration with row highlight and SKU consultation
- add pulse animation for highlighted rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b2c947b8832b8b0f7be374a68d25