### PR TITLE
Ensure pending count uses SKU totals

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -62,7 +62,7 @@ export function sumQuant(obj) {
 export function totalPendentesCount(rz) {
   const tot = getTotals(rz);
   const conf = getConferidos(rz);
-  const totalAll = sumQuant(tot);
+  const totalAll = Object.keys(tot).length; // cada SKU conta 1
   const doneAll = Object.keys(conf).length; // cada SKU conta 1
   return Math.max(0, totalAll - doneAll);
 }

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import store from '../src/store/index.js';
+import store, { totalPendentesCount } from '../src/store/index.js';
 
 describe('store state structure', () => {
   it('has basic keys', () => {
@@ -10,5 +10,16 @@ describe('store state structure', () => {
       conferidosByRZSku: {},
       currentRZ: null,
     });
+  });
+});
+
+describe('totalPendentesCount', () => {
+  it('counts remaining SKUs', () => {
+    const rz = 'RZ_TEST';
+    store.state.totalByRZSku[rz] = { A: 3, B: 2 };
+    store.state.conferidosByRZSku[rz] = { A: { precoAjustado: null, observacao: null } };
+    expect(totalPendentesCount(rz)).toBe(1);
+    delete store.state.totalByRZSku[rz];
+    delete store.state.conferidosByRZSku[rz];
   });
 });


### PR DESCRIPTION
## Summary
- fix `totalPendentesCount` to compare SKU counts consistently
- add unit test covering SKU-based pending count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4e5caef8832bbc6ab5ce4aae071e