### PR TITLE
feat: collapse scanner panel and camera selection

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,8 +31,6 @@
 #preview {
   width: 100%;
   max-height: 360px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: #000;
   object-fit: cover;
+  border-radius: 12px;
 }

--- a/src/utils/scan.js
+++ b/src/utils/scan.js
@@ -13,7 +13,7 @@ async function loadZXing() {
   return ZXing;
 }
 
-export async function iniciarLeitura(videoEl, onText) {
+export async function iniciarLeitura(videoEl, onText, deviceId) {
   if (!videoEl) throw new Error('videoEl ausente');
 
   if (!window.isSecureContext) {
@@ -28,7 +28,10 @@ export async function iniciarLeitura(videoEl, onText) {
     const detector = new window.BarcodeDetector({
       formats: ['qr_code','ean_13','code_128','code_39','upc_a','upc_e'],
     });
-    currentStream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+    const videoConfig = deviceId
+      ? { deviceId: { exact: deviceId } }
+      : { facingMode: 'environment' };
+    currentStream = await navigator.mediaDevices.getUserMedia({ video: videoConfig });
     videoEl.srcObject = currentStream; await videoEl.play();
 
     const loop = async () => {
@@ -67,7 +70,8 @@ export async function iniciarLeitura(videoEl, onText) {
 
   reader = HINTS ? new BrowserMultiFormatReader(HINTS) : new BrowserMultiFormatReader();
 
-  await reader.decodeFromVideoDevice(devices[0].deviceId, videoEl, (result, err) => {
+  const chosen = deviceId || devices[0].deviceId;
+  await reader.decodeFromVideoDevice(chosen, videoEl, (result, err) => {
     if (result) {
       const text = String(result.getText?.() || result.text || '');
       if (text) onText(text);
@@ -81,5 +85,14 @@ export async function pararLeitura(videoEl) {
   reader = null;
   if (videoEl) { try { videoEl.pause(); } catch {} videoEl.srcObject = null; }
   if (currentStream) { currentStream.getTracks().forEach(t=>t.stop()); currentStream = null; }
+}
+
+export async function listarCameras() {
+  try {
+    const devices = await navigator.mediaDevices?.enumerateDevices?.();
+    return devices?.filter(d => d.kind === 'videoinput') || [];
+  } catch {
+    return [];
+  }
 }
 


### PR DESCRIPTION
## Summary
- add toggleable barcode scanner panel that hides video when inactive
- support selecting specific camera and show warning if access fails
- shrink scanner video element and clean up styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e2b18317c832baa52e3137bf620be