### PR TITLE
Improve accessibility and finalize workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,11 +208,26 @@
   <dialog id="dlg-excedente">
     <form method="dialog" id="form-exc">
       <h3>Registrar Excedente</h3>
-      <label>SKU <input id="exc-sku" readonly class="input"></label>
-      <label>Descrição <input id="exc-desc" required class="input"></label>
-      <label>Qtd <input id="exc-qtd" type="number" min="1" value="1" required class="input"></label>
-      <label>Preço unitário (R$) <input id="exc-preco" type="number" step="0.01" min="0.01" required class="input"></label>
-      <label>Observação <input id="exc-obs" class="input"></label>
+      <div class="field">
+        <label for="exc-sku">SKU</label>
+        <input id="exc-sku" readonly class="input" />
+      </div>
+      <div class="field">
+        <label for="exc-desc">Descrição</label>
+        <input id="exc-desc" required class="input" />
+      </div>
+      <div class="field">
+        <label for="exc-qtd">Qtd</label>
+        <input id="exc-qtd" type="number" min="1" value="1" required class="input" />
+      </div>
+      <div class="field">
+        <label for="exc-preco">Preço unitário (R$)</label>
+        <input id="exc-preco" type="number" step="0.01" min="0.01" required class="input" />
+      </div>
+      <div class="field">
+        <label for="exc-obs">Observação</label>
+        <input id="exc-obs" class="input" />
+      </div>
       <menu>
         <button value="cancel" class="btn ghost">Cancelar</button>
         <button id="exc-salvar" value="default" class="btn primary">Salvar excedente</button>

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -86,6 +86,13 @@ export function initActionsPanel(render){
     }
   });
 
+  inputSku?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      btnReg?.click();
+    }
+  });
+
   btnFinal?.addEventListener('click', () => {
     try {
       const rz = store.state.rzAtual;
@@ -106,7 +113,8 @@ export function initActionsPanel(render){
       });
       const excedentes = (store.state.excedentes[rz] || []).map(it=>({ SKU: it.sku, Descrição: it.descricao || '', Qtd: it.qtd, 'Preço Médio (R$)': Number(it.preco || 0), 'Valor Total (R$)': Number(it.qtd||0) * Number(it.preco||0), Observação: it.obs || '' }));
       exportarConferencia({ rz, conferidos, pendentes, excedentes });
-      toast('Planilha exportada', 'info');
+      toast('Conferência finalizada', 'info');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     } catch(e) {
       console.error(e); toast('Falha ao exportar', 'error');
     }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -85,6 +85,7 @@ tr.flash td{ animation: flashBg 1.5s ease; }
 .pagination{ display:flex; gap:var(--space-2); align-items:center; }
 
 :focus-visible{ outline:2px solid var(--primary); outline-offset:2px; border-radius:8px; }
+.btn:focus-visible{ outline:2px solid var(--primary); outline-offset:2px; }
 @media (prefers-reduced-motion: reduce){
   *{ animation: none !important; transition: none !important; }
 }


### PR DESCRIPTION
## Summary
- ensure dialog inputs have labels with `for`
- show focus outlines on buttons for accessibility
- press Enter on SKU input triggers registration
- scroll to top with confirmation toast on finalization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e2f9ea800832bae9b9c758f2a1f77