### PR TITLE
Improve scanner accessibility with live announcements

### DIFF
--- a/src/components/ScannerPanel.js
+++ b/src/components/ScannerPanel.js
@@ -27,6 +27,15 @@ export function initScannerPanel({ onCode }){
   scanMsg.hidden = true;
   btnScan?.insertAdjacentElement('afterend', scanMsg);
 
+  const liveRegion = document.createElement('p');
+  liveRegion.id = 'scanner-live';
+  liveRegion.className = 'sr-only';
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('role', 'status');
+  btnScan?.insertAdjacentElement('afterend', liveRegion);
+
+  const announce = (msg) => { liveRegion.textContent = msg; };
+
   listarCameras()?.then(devs => {
     if (devs.length > 1) {
       camSelect.innerHTML = devs
@@ -56,11 +65,13 @@ export function initScannerPanel({ onCode }){
         await iniciarLeitura(videoEl, (texto)=>{ onDecoded(texto); }, deviceId);
         scanning = true; btnScan.textContent = 'Parar Scanner';
         setBoot('Scanner ativo ▶️');
+        announce('Scanner ativado');
       } else {
         await pararLeitura(videoEl);
         scanning = false; btnScan.textContent = 'Ativar Scanner';
         videoEl.hidden = true;
         setBoot('Scanner parado ⏹️');
+        announce('Scanner parado');
       }
     } catch(err){
       console.error('Erro iniciarLeitura', err);
@@ -69,6 +80,7 @@ export function initScannerPanel({ onCode }){
       videoEl.hidden = true;
       setBoot('Falha ao iniciar scanner ❌ (veja Console)');
       scanning = false; btnScan.textContent = 'Ativar Scanner';
+      announce('Falha ao iniciar scanner');
     }
   });
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -91,3 +91,7 @@ tr.flash td{ animation: flashBg 1.5s ease; }
 }
 
 .hidden{ display:none !important; }
+.sr-only{
+  position:absolute; width:1px; height:1px; padding:0; margin:-1px;
+  overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;
+}


### PR DESCRIPTION
## Summary
- announce scanner activation, stop, and errors via aria-live region
- add `.sr-only` utility class for screen reader-only messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e30e5c5c0832b99d62b57b744ff0f