### PR TITLE
feat: add financial settings and export enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,17 @@
     <header class="toolbar">
       <h1>
         Conferência de Lotes <span id="hdr-conferidos">0 de 0 conferidos</span>
-        <span id="chip-palete" class="chip-info" style="margin-left:8px;" hidden>
+        <span id="chip-palete" class="chip-info" style="margin-left:8px;" hidden title="Média dos preços ML dos itens do palete">
           Preço médio do palete: <span id="val-palete">R$ 0,00</span>
+        </span>
+        <span id="chip-palete-target" class="chip-info" style="margin-left:6px;" hidden title="Preço médio com desconto alvo">
+          Preço‑alvo do palete: <span id="val-palete-target">R$ 0,00</span>
+        </span>
+        <span id="chip-lucro" class="chip-info" style="margin-left:6px;" hidden title="Receita menos custos previstos">
+          Lucro previsto: <span id="val-lucro">R$ 0,00</span>
+        </span>
+        <span id="chip-frete-mode" class="chip-info" style="margin-left:6px;" hidden title="Forma de rateio do frete nos cálculos">
+          Rateio do frete: <span id="val-frete-mode">por unidade</span>
         </span>
       </h1>
       <div class="actions">
@@ -261,6 +270,28 @@
         <label for="cfg-page-size" class="label">Itens por seção (padrão)</label>
         <select id="cfg-page-size" class="input">
           <option>25</option><option selected>50</option><option>100</option><option>200</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="cfg-discount" class="label">Desconto alvo abaixo do preço ML (%)</label>
+        <input id="cfg-discount" type="number" class="input" value="25" min="0" max="90" step="1" />
+      </div>
+
+      <div class="field">
+        <label for="cfg-auction-fee" class="label">Taxa do leilão (%)</label>
+        <input id="cfg-auction-fee" type="number" class="input" value="8" min="0" max="50" step="0.1" />
+      </div>
+
+      <div class="field">
+        <label for="cfg-freight" class="label">Frete total (R$) — opcional</label>
+        <input id="cfg-freight" type="number" class="input" value="0" min="0" step="0.01" />
+      </div>
+
+      <div class="field">
+        <label for="cfg-freight-mode" class="label">Rateio do frete</label>
+        <select id="cfg-freight-mode" class="input">
+          <option value="por_unidade" selected>Por unidade</option>
+          <option value="por_valor">Proporcional ao valor</option>
         </select>
       </div>
       <menu style="display:flex;gap:8px;justify-content:flex-end">

--- a/src/components/ResultsPanel.js
+++ b/src/components/ResultsPanel.js
@@ -70,5 +70,5 @@ export function renderResults(){
   const bp = document.getElementById('count-pendentes'); if (bp) bp.textContent = cont.total - cont.conferidos;
   const be = document.getElementById('excedentesCount'); if (be) be.textContent = cont.excedentes || 0;
   updateToggleLabels();
-  window.updateChipPalete?.();
+  window.refreshFinancialChips?.();
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -74,14 +74,17 @@ export function addConferido(rz, sku, payload = {}) {
   const map = (state.conferidosByRZSku[rz] ||= {});
   const total = state.totalByRZSku[rz]?.[sku] || 0;
   const qty = Math.max(1, parseInt(payload.qty ?? 1, 10));
-  const existente = map[sku] || { qtd: 0, precoAjustado: null, observacao: null, status: null };
+  const existente = map[sku] || { qtd: 0, precoAjustado: null, observacao: null, status: null, avariados: 0 };
   const restante = Math.max(0, total - existente.qtd);
   const efetivo = Math.min(qty, restante);
   if (efetivo <= 0) return;
   existente.qtd += efetivo;
   if (payload.precoAjustado !== undefined) existente.precoAjustado = payload.precoAjustado;
   if (payload.observacao) existente.observacao = payload.observacao;
-  if (payload.avaria) existente.status = 'avariado';
+  if (payload.avaria) {
+    existente.status = 'avariado';
+    existente.avariados = (existente.avariados || 0) + efetivo;
+  }
   map[sku] = existente;
   state.movimentos.push({ ts: Date.now(), rz, sku, qty: efetivo, precoAjustado: existente.precoAjustado, observacao: existente.observacao, status: existente.status });
   updateContadores(rz);

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -220,10 +220,41 @@ export function exportarConferencia({ conferidos, pendentes, excedentes, resumoR
     XLSX.utils.book_append_sheet(wb, ws, nome);
   }
 
+  function sheetFinanceiroPorItem(){
+    const f = (typeof window !== 'undefined' && window.computeFinancials) ? window.computeFinancials() : null;
+    if (!f) return [];
+    return f.byItem.map(it => ({
+      'SKU': it.sku,
+      'Descrição': it.descricao,
+      'Preço ML (R$)': it.ml,
+      'Preço‑alvo (R$)': it.target,
+      'Custo unit. (R$)': it.unitCost,
+      'Unid. vendáveis': it.unitsVend,
+      'Receita (R$)': it.revenue,
+      'Custo (R$)': it.cost,
+      'Lucro (R$)': it.profit
+    }));
+  }
+
   addSheet('Conferidos', conferidos, ['SKU','Descrição','Qtd','Preço Médio (R$)','Valor Total (R$)']);
   addSheet('Pendentes', pendentes, ['SKU','Descrição','Qtd','Preço Médio (R$)','Valor Total (R$)']);
   addSheet('Excedentes', excedentes, ['SKU','Descrição','Qtd','Preço Médio (R$)','Valor Total (R$)']);
-  addSheet('Resumo RZ', resumoRZ, ['RZ','Conferidos','Pendentes','Excedentes','Valor Total (R$)']);
+  const fin = (typeof window !== 'undefined' && window.computeFinancials) ? window.computeFinancials() : null;
+  addSheet('Resumo RZ', resumoRZ.map(r => ({
+    'RZ': r.rz,
+    'Conferidos': r.conferidos,
+    'Pendentes': r.pendentes,
+    'Excedentes': r.excedentes,
+    'Valor Total (R$)': r.valorTotal,
+    'Palete ML (R$)': fin?.totals.paleteMLavg,
+    'Palete alvo (R$)': fin?.totals.paleteTarget,
+    'Lucro previsto (R$)': fin?.totals.lucroPrevisto,
+  })), ['RZ','Conferidos','Pendentes','Excedentes','Valor Total (R$)','Palete ML (R$)','Palete alvo (R$)','Lucro previsto (R$)']);
+
+  addSheet('Financeiro (por item)', sheetFinanceiroPorItem(), [
+    'SKU','Descrição','Preço ML (R$)','Preço‑alvo (R$)','Custo unit. (R$)',
+    'Unid. vendáveis','Receita (R$)','Custo (R$)','Lucro (R$)'
+  ]);
 
   XLSX.writeFile(wb, `conferencia_${new Date().toISOString().slice(0,10)}.xlsx`);
 }


### PR DESCRIPTION
## Summary
- allow configuring discount, auction fee and freight mode with persistent settings
- calculate per-item and palette financial projections with header chips
- include financial breakdown in Excel export and track avariados units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e68b66ecc832b959bcf97b57a526a