### PR TITLE
feat: parse NCM column

### DIFF
--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -54,6 +54,7 @@ function buildHeaderMap(headerCells) {
     if (/valor\s*tot/.test(n)) map.valorTotal = idx;
     if (/^categoria$/.test(n)) map.categoria = idx;
     if (/subcat/.test(n)) map.subcategoria = idx;
+    if (n.replace(/\./g, '') === 'ncm' || n === 'ncm_code') map.ncm = idx;
   });
   return map;
 }
@@ -65,6 +66,11 @@ function parseNumberBR(v) {
   const t = s.replace(/\./g, '').replace(',', '.');
   const n = Number(t);
   return Number.isFinite(n) ? n : 0;
+}
+
+function sanitizeNCM(n) {
+  const onlyDigits = String(n ?? '').replace(/\D/g, '');
+  return /^\d{8}$/.test(onlyDigits) ? onlyDigits : null;
 }
 
 function normalizeRZ(v) {
@@ -123,6 +129,7 @@ export async function processarPlanilha(input) {
         valorTotal: parseNumberBR(get('valorTotal')),
         categoria: get('categoria'),
         subcategoria: get('subcategoria'),
+        ncm: sanitizeNCM(get('ncm')),
         _rowIndex: i + 1,
       };
       if (obj.codigoRZ) items.push(obj);
@@ -146,8 +153,9 @@ export async function processarPlanilha(input) {
 
         const descricao = String(it.descricao || '').trim();
         const precoMedio = Number(it.valorUnit || 0);
+        const ncm = it.ncm || null;
         (metaByRZSku[rz] ||= {});
-        if (!metaByRZSku[rz][sku]) metaByRZSku[rz][sku] = { descricao, precoMedio };
+        if (!metaByRZSku[rz][sku]) metaByRZSku[rz][sku] = { descricao, precoMedio, ncm };
       }
       totalByRZSku[rz] = map;
     }

--- a/tests/excel.spec.js
+++ b/tests/excel.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as XLSX from 'xlsx';
 import { processarPlanilha } from '../src/utils/excel.js';
+import store from '../src/store/index.js';
 
 function createXlsxBuffer(data){
   const ws = XLSX.utils.aoa_to_sheet(data);
@@ -15,15 +16,26 @@ describe('processarPlanilha', () => {
       const data = [
         ['alguma coisa', 'foo'],
         [],
-        ['Codigo ML', 'Descricao', 'Qtd', 'Cod RZ', 'Valor Unit'],
-        ['AAA123', 'Produto A', 2, 'RZ-123', 10.5],
-        ['BBB456', 'Produto B', '1', 'RZ-124', 5],
-        ['TOTAL', '', { f: 'SUM(C4:C5)' }, 'RZ-123', 0],
+        ['Codigo ML', 'Descricao', 'Qtd', 'Cod RZ', 'Valor Unit', 'NCM'],
+        ['AAA123', 'Produto A', 2, 'RZ-123', 10.5, '12.34.56.78'],
+        ['BBB456', 'Produto B', '1', 'RZ-124', 5, '87654321'],
+        ['TOTAL', '', { f: 'SUM(C4:C5)' }, 'RZ-123', 0, ''],
       ];
       const buf = createXlsxBuffer(data);
       const { rzList, itemsByRZ } = await processarPlanilha(buf);
       expect(rzList).toEqual(['RZ-123', 'RZ-124']);
-      expect(itemsByRZ['RZ-123'][0]).toMatchObject({ codigoML: 'AAA123', codigoRZ: 'RZ-123', qtd: 2 });
-      expect(itemsByRZ['RZ-124'][0]).toMatchObject({ codigoML: 'BBB456', codigoRZ: 'RZ-124', qtd: 1 });
+        expect(itemsByRZ['RZ-123'][0]).toMatchObject({ codigoML: 'AAA123', codigoRZ: 'RZ-123', qtd: 2, ncm: '12345678' });
+        expect(itemsByRZ['RZ-124'][0]).toMatchObject({ codigoML: 'BBB456', codigoRZ: 'RZ-124', qtd: 1, ncm: '87654321' });
+    });
+
+    it('sanitiza NCM e salva no metaByRZSku', async () => {
+      const data = [
+        ['Codigo ML', 'Descricao', 'Qtd', 'Cod RZ', 'Valor Unit', 'N.C.M.'],
+        ['AAA123', 'Produto A', 1, 'RZ-999', 2.5, '00.11.22.33'],
+      ];
+      const buf = createXlsxBuffer(data);
+      const { itemsByRZ } = await processarPlanilha(buf);
+      expect(itemsByRZ['RZ-999'][0].ncm).toBe('00112233');
+      expect(store.state.metaByRZSku['RZ-999']['AAA123'].ncm).toBe('00112233');
     });
   });


### PR DESCRIPTION
## Summary
- parse NCM column from spreadsheets and store 8-digit code
- add tests for NCM parsing and storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e6f4f729c832bb137aa504848e47f