### PR TITLE
feat: exibir ncm no card do produto

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
               <div class="kv"><span class="muted">Preço médio (R$)</span><span id="pi-preco">0,00</span></div>
               <div class="kv"><span class="muted">Valor total (R$)</span><span id="pi-total">0,00</span></div>
               <div class="kv"><span class="muted">RZ</span><span id="pi-rz">—</span></div>
+              <div class="kv"><span class="muted">NCM</span><span id="pi-ncm">—</span></div>
             </div>
           </section>
 

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -18,6 +18,7 @@ function mostrarProdutoInfo(item) {
   $('#pi-preco').textContent = Number(item.precoMedio || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
   $('#pi-total').textContent = Number((item.qtd || 0) * (item.precoMedio || 0)).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
   $('#pi-rz').textContent = store.state.rzAtual || '';
+  document.getElementById('pi-ncm').textContent = item?.ncm || '—';
   document.getElementById('produto-info').hidden = false;
 }
 


### PR DESCRIPTION
## Summary
- exibe campo NCM no card de informações do produto
- popula o NCM com o valor do item ou traço quando ausente

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e8567e000832b884e56c944225106