### PR TITLE
feat: enhance NCM handling with cache and queue

### DIFF
--- a/src/services/ncmService.js
+++ b/src/services/ncmService.js
@@ -1,30 +1,109 @@
 import { RUNTIME } from '../config/runtime.js';
 
+const CACHE_KEY = 'ncmCache:v1';
 const memCache = new Map();
-function readLocalCache(){try{return JSON.parse(localStorage.getItem(RUNTIME.CACHE_KEY)||'{}')}catch{return{}}}
-function writeLocalCache(o){try{localStorage.setItem(RUNTIME.CACHE_KEY,JSON.stringify(o||{}))}catch{}}
-function cacheGet(k){ if(memCache.has(k)) return memCache.get(k); const all=readLocalCache(); return all[k]||null; }
-function cacheSet(k,v){ memCache.set(k,v); const all=readLocalCache(); all[k]=v; writeLocalCache(all); }
+(function load(){
+  try{
+    const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+    for(const [k,v] of Object.entries(raw)) memCache.set(k,v);
+  }catch{}
+})();
+function saveCache(){
+  try{ localStorage.setItem(CACHE_KEY, JSON.stringify(Object.fromEntries(memCache))); }catch{}
+}
+export function cacheGet(k){ return memCache.get(k)||null; }
+export function cacheSet(k,v){ memCache.set(k,v); saveCache(); }
 
-export function sanitizeNCM(n){ const d=String(n??'').replace(/\D/g,''); return /^\d{8}$/.test(d)?d:null; }
+export function normalizeNCM(n){
+  const d = String(n ?? '').replace(/\D/g, '');
+  return /^\d{8}$/.test(d) ? d : null;
+}
 
-async function fetchLocalMap(){ try{ const r=await fetch(RUNTIME.NCM_LOCAL_MAP_URL,{cache:'no-store'}); if(!r.ok) return []; return await r.json(); }catch{return[]} }
+export function createQueue(limit = 3){
+  const queue = [];
+  let active = 0;
+  const next = () => {
+    if(active >= limit || queue.length === 0) return;
+    const {fn, resolve, reject} = queue.shift();
+    active++;
+    Promise.resolve().then(fn).then(resolve, reject).finally(()=>{ active--; next(); });
+  };
+  return function enqueue(fn){
+    return new Promise((resolve,reject)=>{
+      queue.push({fn, resolve, reject});
+      next();
+    });
+  };
+}
+
+export async function resolveWithRetry(fn, attempts=3, baseDelay=100){
+  let lastErr;
+  for(let i=0;i<attempts;i++){
+    try{ return await fn(); }
+    catch(err){ lastErr = err; if(i < attempts-1){ await new Promise(r=>setTimeout(r, baseDelay * Math.pow(2,i))); }}
+  }
+  throw lastErr;
+}
+
+async function fetchLocalMap(){
+  try{
+    const r = await fetch(RUNTIME.NCM_LOCAL_MAP_URL, {cache:'no-store'});
+    if(!r.ok) return [];
+    return await r.json();
+  }catch{return[];}
+}
 
 async function fetchFromAPIByDesc(desc){
-  if(!RUNTIME.NCM_API_BASE) return null;
+  if(!RUNTIME.NCM_API_BASE) throw new Error('no_api');
   const url = `${RUNTIME.NCM_API_BASE}/ncm?descricao=${encodeURIComponent(desc)}`;
-  const headers = {}; if(RUNTIME.NCM_API_TOKEN) headers.Authorization=`Bearer ${RUNTIME.NCM_API_TOKEN}`;
-  try{ const r=await fetch(url,{headers}); if(!r.ok) return null; const data=await r.json();
-       const first=Array.isArray(data)?data[0]:null; const code=first?.codigoNcm||first?.codigo||null;
-       const d=String(code||'').replace(/\D/g,''); return /^\d{8}$/.test(d)?d:null; }catch{return null}
+  const headers = {};
+  if(RUNTIME.NCM_API_TOKEN) headers.Authorization = `Bearer ${RUNTIME.NCM_API_TOKEN}`;
+  const controller = new AbortController();
+  const t = setTimeout(()=>controller.abort(), 8000);
+  try{
+    const r = await fetch(url,{headers, signal:controller.signal});
+    if(!r.ok){ const err = new Error('http_error'); err.status = r.status; throw err; }
+    const data = await r.json();
+    const first = Array.isArray(data)?data[0]:null;
+    const code = first?.codigoNcm || first?.codigo || null;
+    return normalizeNCM(code);
+  }catch(err){
+    if(err.name === 'AbortError'){ err.reason = 'timeout'; }
+    throw err;
+  }finally{ clearTimeout(t); }
 }
 
-export async function resolveNCM({ sku, ncmPlanilha, descricao }){
-  const direct=sanitizeNCM(ncmPlanilha); if(direct){ cacheSet(sku,direct); return direct; }
-  const cached=cacheGet(sku); if(cached) return cached;
-  const map=await fetchLocalMap(); const found=map.find(x=>String(x.sku).toLowerCase()===String(sku).toLowerCase());
-  const local=sanitizeNCM(found?.ncm); if(local){ cacheSet(sku,local); return local; }
-  const api=await fetchFromAPIByDesc(descricao||sku); if(api){ cacheSet(sku,api); return api; }
-  return null;
+export async function resolve(args){
+  const { sku, ncmPlanilha, descricao } = args;
+  const direct = normalizeNCM(ncmPlanilha);
+  if(direct){ cacheSet(sku,direct); return { ok:true, ncm:direct, source:'row' }; }
+  const cached = cacheGet(sku);
+  if(cached) return { ok:true, ncm:cached, source:'cache' };
+  const map = await fetchLocalMap();
+  const found = map.find(x => String(x.sku).toLowerCase() === String(sku).toLowerCase());
+  const local = normalizeNCM(found?.ncm);
+  if(local){ cacheSet(sku,local); return { ok:true, ncm:local, source:'map' }; }
+  try{
+    const api = await resolveWithRetry(()=>fetchFromAPIByDesc(descricao||sku));
+    if(api){ cacheSet(sku,api); return { ok:true, ncm:api, source:'api' }; }
+    return { ok:false, reason:'api_no_ncm' };
+  }catch(err){
+    if(err.status) return { ok:false, reason:'api_http_error', detail:String(err.status) };
+    if(err.reason==='timeout') return { ok:false, reason:'api_timeout' };
+    if(err.message==='no_api') return { ok:false, reason:'no_api' };
+    return { ok:false, reason:'api_exception', detail: String(err.message||err) };
+  }
 }
+
+const enqueue = createQueue(3);
+export function resolveQueued(args){
+  return enqueue(()=>resolve(args));
+}
+
+export async function resolveNCM(args){
+  const r = await resolve(args);
+  return r.ok ? r.ncm : null;
+}
+
+export default { normalizeNCM, resolve, resolveQueued, resolveNCM };
 

--- a/tests/ncmService.spec.js
+++ b/tests/ncmService.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { normalizeNCM, createQueue, resolveWithRetry, resolve } from '../src/services/ncmService.js';
+
+describe('normalizeNCM', () => {
+  it('ensures 8 digits', () => {
+    expect(normalizeNCM('12.345.678')).toBe('12345678');
+    expect(normalizeNCM('abc')).toBeNull();
+  });
+});
+
+describe('cache and resolve', () => {
+  it('uses cache after first resolution', async () => {
+    localStorage.clear();
+    const r1 = await resolve({ sku:'A', ncmPlanilha:'12345678' });
+    expect(r1).toMatchObject({ ok:true, ncm:'12345678', source:'row' });
+    const r2 = await resolve({ sku:'A' });
+    expect(r2).toMatchObject({ ok:true, ncm:'12345678', source:'cache' });
+  });
+});
+
+describe('createQueue', () => {
+  it('limits concurrency', async () => {
+    const enqueue = createQueue(2);
+    let active = 0, max = 0;
+    const task = (ms) => enqueue(()=> new Promise(res => { active++; max=Math.max(max,active); setTimeout(()=>{ active--; res(); }, ms); }));
+    await Promise.all([task(20), task(20), task(20)]);
+    expect(max).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('resolveWithRetry', () => {
+  it('retries failing function', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValue('ok');
+    const res = await resolveWithRetry(fn,3,10);
+    expect(res).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('resolve error cases', () => {
+  it('handles http error', async () => {
+    localStorage.clear();
+    global.fetch = vi.fn().mockResolvedValue({ ok:false, status:403 });
+    const r = await resolve({ sku:'X', descricao:'x' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('api_http_error');
+  });
+
+  it('handles api without ncm', async () => {
+    localStorage.clear();
+    global.fetch = vi.fn().mockResolvedValue({ ok:true, json:async()=>[], });
+    const r = await resolve({ sku:'Y', descricao:'y' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('api_no_ncm');
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,16 @@ import { beforeAll, afterAll, vi } from 'vitest';
 let warnSpy;
 const verbose = process.env.VERBOSE === '1' || process.env.CONFER_VERBOSE === '1';
 
+if (typeof globalThis.localStorage === 'undefined') {
+  let store: Record<string, string> = {};
+  globalThis.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+    clear: () => { store = {}; },
+  } as any;
+}
+
 beforeAll(() => {
   if (!verbose) {
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import store, { totalPendentesCount } from '../src/store/index.js';
+import store, { totalPendentesCount, setItemNcm, setItemNcmStatus, selectAllItems } from '../src/store/index.js';
 
 describe('store state structure', () => {
   it('has basic keys', () => {
@@ -21,5 +21,34 @@ describe('totalPendentesCount', () => {
     expect(totalPendentesCount(rz)).toBe(1);
     delete store.state.totalByRZSku[rz];
     delete store.state.conferidosByRZSku[rz];
+  });
+});
+
+describe('NCM helpers', () => {
+  it('setItemNcm saves data and cache', () => {
+    const id = 'RZ1:SKU1';
+    store.state.metaByRZSku['RZ1'] = { SKU1: { descricao: 'x' } };
+    setItemNcm(id, '12345678', 'api');
+    expect(store.state.metaByRZSku['RZ1'].SKU1).toMatchObject({ ncm: '12345678', ncm_source: 'api', ncm_status: 'ok' });
+    const cache = JSON.parse(localStorage.getItem('ncmCache:v1'));
+    expect(cache).toHaveProperty('SKU1', '12345678');
+  });
+
+  it('setItemNcmStatus updates status', () => {
+    const id = 'RZ1:SKU1';
+    setItemNcmStatus(id, 'pendente:api');
+    expect(store.state.metaByRZSku['RZ1'].SKU1.ncm_status).toBe('pendente:api');
+  });
+
+  it('selectAllItems merges arrays', () => {
+    store.state.currentRZ = 'RZ1';
+    store.state.totalByRZSku['RZ1'] = { SKU1: 1, SKU2: 2 };
+    store.state.metaByRZSku['RZ1'].SKU2 = { descricao: 'y' };
+    store.state.excedentes['RZ1'] = [{ sku: 'EX1', descricao: 'z', qtd: 1 }];
+    const all = selectAllItems();
+    const ids = all.map(it => it.id);
+    expect(ids).toContain('RZ1:SKU1');
+    expect(ids).toContain('RZ1:SKU2');
+    expect(ids).toContain('RZ1:EX1');
   });
 });


### PR DESCRIPTION
## Summary
- add NCM cache, tagging and selection helpers to store
- implement NCM service queue, retry and persistent cache
- cover NCM helpers with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e8de59b14832bb2877723694bfe41