### PR TITLE
feat: add configurable finance indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,23 +10,19 @@
     <header class="toolbar">
       <h1>
         Conferência de Lotes <span id="hdr-conferidos">0 de 0 conferidos</span>
-        <span id="chip-palete" class="chip-info" style="margin-left:8px;" hidden title="Média dos preços ML dos itens do palete">
-          Preço médio do palete: <span id="val-palete">R$ 0,00</span>
-        </span>
-        <span id="chip-palete-target" class="chip-info" style="margin-left:6px;" hidden title="Preço médio com desconto alvo">
-          Preço‑alvo do palete: <span id="val-palete-target">R$ 0,00</span>
-        </span>
-        <span id="chip-lucro" class="chip-info" style="margin-left:6px;" hidden title="Receita menos custos previstos">
-          Lucro previsto: <span id="val-lucro">R$ 0,00</span>
-        </span>
-        <span id="chip-frete-mode" class="chip-info" style="margin-left:6px;" hidden title="Forma de rateio do frete nos cálculos">
-          Rateio do frete: <span id="val-frete-mode">por unidade</span>
-        </span>
       </h1>
       <div class="actions">
         <button id="helpBtn" title="Ajuda/Atalhos" aria-label="Ajuda" class="btn ghost">?</button>
       </div>
     </header>
+
+    <section id="indicators" class="indicators hidden">
+      <div class="indicators-toolbar">
+        <button id="toggle-indicators">Mostrar indicadores</button>
+        <button id="config-indicators" title="Configurar indicadores">⚙️</button>
+      </div>
+      <div class="indicators-grid"></div>
+    </section>
 
     <div class="layout-grid">
       <section id="card-importacao" class="card">
@@ -92,6 +88,35 @@
               <div class="kv"><span class="muted">Valor total (R$)</span><span id="pi-total">0,00</span></div>
               <div class="kv"><span class="muted">RZ</span><span id="pi-rz">—</span></div>
               <div class="kv"><span class="muted">NCM</span><span id="pi-ncm">—</span></div>
+            </div>
+          </section>
+
+          <section id="finance-controls" class="card">
+            <div class="card-header">
+              <h3>Financeiro</h3>
+            </div>
+            <div class="card-body">
+              <div class="field">
+                <label for="fin-percent" class="label">Pagamos % do preço ML</label>
+                <input type="range" id="fin-percent" min="0" max="50" step="1" class="input" />
+                <span id="fin-percent-val">20%</span>
+              </div>
+              <div class="field">
+                <label for="fin-desconto" class="label">Desconto venda vs ML</label>
+                <input type="range" id="fin-desconto" min="0" max="50" step="1" class="input" />
+                <span id="fin-desconto-val">20%</span>
+              </div>
+              <div class="field">
+                <label for="fin-frete" class="label">Frete total</label>
+                <input type="number" id="fin-frete" class="input" step="0.01" />
+              </div>
+              <div class="field">
+                <label for="fin-rateio" class="label">Rateio do frete</label>
+                <select id="fin-rateio" class="input">
+                  <option value="valor">por valor</option>
+                  <option value="quantidade">por quantidade</option>
+                </select>
+              </div>
             </div>
           </section>
 
@@ -298,6 +323,17 @@
       <menu style="display:flex;gap:8px;justify-content:flex-end">
         <button value="cancel" class="btn ghost">Cancelar</button>
         <button value="default" class="btn primary">Salvar</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="dlg-indicators">
+    <form method="dialog">
+      <h3>Selecionar indicadores</h3>
+      <div id="metrics-options"></div>
+      <menu style="display:flex;gap:8px;justify-content:flex-end;margin-top:8px;">
+        <button value="cancel" class="btn ghost">Cancelar</button>
+        <button id="apply-indicators" value="default" class="btn primary">Aplicar</button>
       </menu>
     </form>
   </dialog>

--- a/src/components/ResultsPanel.js
+++ b/src/components/ResultsPanel.js
@@ -70,5 +70,5 @@ export function renderResults(){
   const bp = document.getElementById('count-pendentes'); if (bp) bp.textContent = cont.total - cont.conferidos;
   const be = document.getElementById('excedentesCount'); if (be) be.textContent = cont.excedentes || 0;
   updateToggleLabels();
-  window.refreshFinancialChips?.();
+  window.refreshIndicators?.();
 }

--- a/src/config/finance.js
+++ b/src/config/finance.js
@@ -1,0 +1,6 @@
+export const FINANCE = {
+  percent_pago_sobre_ml: 0.20,     // pagamos 20% do preço médio ML
+  desconto_venda_vs_ml:  0.20,     // vendemos 20% abaixo do preço médio ML
+  frete_total: 0,                  // R$ total do frete do lote (editável)
+  rateio_frete: 'valor',           // 'valor' | 'quantidade'
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,3 +61,23 @@ tr.avariado {
   background: rgba(239,68,68,.15);
 }
 
+.indicators { margin: 16px 0; }
+.indicators.hidden { display: none; }
+
+.indicators-toolbar {
+  display: flex; gap: 8px; align-items: center; justify-content: flex-end; margin-bottom: 8px;
+}
+
+.indicators-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px;
+}
+
+.metric-card {
+  background: #fff; border: 1px solid rgba(0,0,0,.06);
+  border-radius: 14px; padding: 14px 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06);
+}
+
+.metric-label { font-size: 12px; color: #556; letter-spacing:.2px; }
+.metric-value { font-size: 22px; font-weight: 700; margin-top: 4px; }
+.metric-footnote { font-size: 11px; color: #889; margin-top: 6px; }
+

--- a/src/utils/finance.js
+++ b/src/utils/finance.js
@@ -1,0 +1,94 @@
+import { FINANCE } from '../config/finance.js';
+
+export const FINANCE_KEY = 'config:finance:v1';
+export const METRICS_PREFS_KEY = 'ui:metricsPrefs:v1';
+
+export const DEFAULT_METRICS_PREFS = {
+  showIndicators: false,
+  visible: {
+    preco_medio_ml_palete: false,
+    custo_medio_pago_palete: false,
+    preco_venda_medio_palete: false,
+    lucro_total_palete: false,
+    rateio_frete: false,
+  }
+};
+
+export function loadFinanceConfig() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(FINANCE_KEY) || '{}');
+    return { ...FINANCE, ...saved };
+  } catch {
+    return { ...FINANCE };
+  }
+}
+
+export function saveFinanceConfig(cfg) {
+  localStorage.setItem(FINANCE_KEY, JSON.stringify(cfg || {}));
+}
+
+export function loadMetricsPrefs() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(METRICS_PREFS_KEY) || '{}');
+    return {
+      ...DEFAULT_METRICS_PREFS,
+      ...saved,
+      visible: { ...DEFAULT_METRICS_PREFS.visible, ...(saved?.visible || {}) },
+    };
+  } catch {
+    return { ...DEFAULT_METRICS_PREFS, visible: { ...DEFAULT_METRICS_PREFS.visible } };
+  }
+}
+
+export function saveMetricsPrefs(prefs) {
+  localStorage.setItem(METRICS_PREFS_KEY, JSON.stringify(prefs || {}));
+}
+
+export function computeFreteUnit(item, ctx) {
+  const preco = Number(item.preco_ml_unit || 0);
+  const qtd = Number(item.qtd || 0);
+  const frete = Number(ctx.frete_total || 0);
+  const rateio = ctx.rateio_frete;
+  const totalValor = Number(ctx.totalValor || 0);
+  const totalQtd = Number(ctx.totalQtd || 0);
+  if (frete <= 0) return 0;
+  if (rateio === 'valor') {
+    if (totalValor <= 0) return 0;
+    const peso = (preco * qtd) / totalValor;
+    return (frete * peso) / Math.max(1, qtd);
+  } else {
+    if (totalQtd <= 0) return 0;
+    return (qtd / totalQtd) * frete / Math.max(1, qtd);
+  }
+}
+
+export function computeItemFinance(item, config, ctx) {
+  const preco = Number(item.preco_ml_unit || 0);
+  const qtd = Number(item.qtd || 0);
+  const custo_pago_unit = preco * Number(config.percent_pago_sobre_ml || 0);
+  const preco_venda_unit = preco * (1 - Number(config.desconto_venda_vs_ml || 0));
+  const frete_unit = computeFreteUnit({ preco_ml_unit: preco, qtd }, { ...ctx, ...config });
+  const lucro_unit = preco_venda_unit - custo_pago_unit - frete_unit;
+  const lucro_total = lucro_unit * qtd;
+  return { custo_pago_unit, preco_venda_unit, frete_unit, lucro_unit, lucro_total };
+}
+
+export function computeAggregates(lista, config) {
+  const totalQtd = lista.reduce((s, it) => s + Number(it.qtd || 0), 0);
+  const totalValor = lista.reduce((s, it) => s + Number(it.preco_ml_unit || 0) * Number(it.qtd || 0), 0);
+  let sumCusto = 0, sumVenda = 0, sumML = 0, sumLucro = 0;
+  for (const it of lista) {
+    const ctx = { totalValor, totalQtd, frete_total: config.frete_total, rateio_frete: config.rateio_frete };
+    const fin = computeItemFinance(it, config, ctx);
+    const q = Number(it.qtd || 0);
+    sumCusto += fin.custo_pago_unit * q;
+    sumVenda += fin.preco_venda_unit * q;
+    sumML += Number(it.preco_ml_unit || 0) * q;
+    sumLucro += fin.lucro_total;
+  }
+  const preco_medio_ml_palete = totalQtd > 0 ? sumML / totalQtd : 0;
+  const custo_medio_pago_palete = totalQtd > 0 ? sumCusto / totalQtd : 0;
+  const preco_venda_medio_palete = totalQtd > 0 ? sumVenda / totalQtd : 0;
+  const lucro_total_palete = sumLucro;
+  return { preco_medio_ml_palete, custo_medio_pago_palete, preco_venda_medio_palete, lucro_total_palete };
+}

--- a/tests/finance.spec.js
+++ b/tests/finance.spec.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { computeFreteUnit, computeItemFinance, loadMetricsPrefs, saveMetricsPrefs } from '../src/utils/finance.js';
+
+describe('finance computations', () => {
+  it('base case quantity rateio', () => {
+    const item = { preco_ml_unit: 100, qtd: 1 };
+    const config = { percent_pago_sobre_ml: 0.20, desconto_venda_vs_ml: 0.20, frete_total: 10, rateio_frete: 'quantidade' };
+    const ctx = { totalQtd: 5, totalValor: 500, frete_total: 10, rateio_frete: 'quantidade' };
+    const res = computeItemFinance(item, config, ctx);
+    expect(res.custo_pago_unit).toBeCloseTo(20);
+    expect(res.preco_venda_unit).toBeCloseTo(80);
+    expect(res.frete_unit).toBeCloseTo(2);
+    expect(res.lucro_unit).toBeCloseTo(58);
+  });
+
+  it('rateio por valor distribui corretamente', () => {
+    const items = [
+      { preco_ml_unit: 100, qtd: 1 },
+      { preco_ml_unit: 200, qtd: 1 }
+    ];
+    const ctx = { totalQtd: 2, totalValor: 300, frete_total: 30, rateio_frete: 'valor' };
+    const f1 = computeFreteUnit(items[0], ctx);
+    const f2 = computeFreteUnit(items[1], ctx);
+    expect(f1).toBeCloseTo(10);
+    expect(f2).toBeCloseTo(20);
+  });
+});
+
+describe('metrics prefs persistence', () => {
+  beforeEach(() => localStorage.removeItem('ui:metricsPrefs:v1'));
+  it('persists selections', () => {
+    const prefs = loadMetricsPrefs();
+    prefs.showIndicators = true;
+    prefs.visible.preco_medio_ml_palete = true;
+    saveMetricsPrefs(prefs);
+    const again = loadMetricsPrefs();
+    expect(again.showIndicators).toBe(true);
+    expect(again.visible.preco_medio_ml_palete).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace old chips with configurable indicator cards and localStorage-backed visibility settings
- implement finance utilities and expose configuration controls with persistence
- update Excel exports and add unit tests for new financial logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e966568cc832b80e1775169edbb25