### PR TITLE
Add scanner mode preferences and discard tracking

### DIFF
--- a/src/components/ExcedenteModal.js
+++ b/src/components/ExcedenteModal.js
@@ -1,0 +1,30 @@
+// Implementação simplificada para registrar observação de excedente
+// Retorna uma Promise que resolve com a string informada (pode ser vazia)
+// Para testes, o estado atual do modal pode ser acessado via getCurrentModal()
+
+let currentModal = null;
+
+export function openExcedenteModal({ defaultValue = '' } = {}) {
+  return new Promise((resolve) => {
+    currentModal = {
+      value: defaultValue,
+      confirm() {
+        const val = currentModal.value || '';
+        currentModal = null;
+        resolve(val);
+      },
+      cancel() {
+        currentModal = null;
+        resolve(null);
+      },
+      keypress(key) {
+        if (key === 'Enter') currentModal.confirm();
+        if (key === 'Escape') currentModal.cancel();
+      },
+    };
+  });
+}
+
+export function getCurrentModal() {
+  return currentModal;
+}

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -1,20 +1,29 @@
-export const PREFS_KEY = 'ui:prefs:v1';
+// src/utils/prefs.js
+// Helper de persistência simples para preferências de UI
 
+export const UIPREFS_KEY = 'ui:prefs:v2';
+
+// Valores padrão das preferências da interface
+// Mantém chaves antigas por compatibilidade com código existente
 const DEFAULT_PREFS = {
   showFinance: false,
   showIndicators: false,
   calcFreteMode: 'finalizar',
+  scannerMode: 'auto',
+  lockManualScanner: false,
+  askDiscardOnFinalize: true,
 };
 
-export function loadPrefs(){
-  try{
-    const saved = JSON.parse(localStorage.getItem(PREFS_KEY) || '{}');
+export function loadPrefs() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(UIPREFS_KEY) || '{}');
     return { ...DEFAULT_PREFS, ...saved };
-  }catch{
+  } catch {
     return { ...DEFAULT_PREFS };
   }
 }
 
-export function savePrefs(p){
-  localStorage.setItem(PREFS_KEY, JSON.stringify(p||{}));
+export function savePrefs(v) {
+  localStorage.setItem(UIPREFS_KEY, JSON.stringify(v || {}));
 }
+

--- a/src/utils/scannerController.js
+++ b/src/utils/scannerController.js
@@ -1,0 +1,41 @@
+import { loadPrefs, savePrefs } from './prefs.js';
+
+let currentMode = 'auto';
+const listeners = new Set();
+
+function init() {
+  const prefs = loadPrefs();
+  currentMode = prefs.scannerMode || 'auto';
+}
+
+init();
+
+export function getMode() {
+  return currentMode;
+}
+
+export function switchTo(mode = 'auto') {
+  currentMode = mode === 'manual' ? 'manual' : 'auto';
+  const prefs = loadPrefs();
+  prefs.scannerMode = currentMode;
+  savePrefs(prefs);
+  listeners.forEach((fn) => fn(currentMode));
+}
+
+export function afterRegister() {
+  const prefs = loadPrefs();
+  if (prefs.lockManualScanner) {
+    // mantém modo manual se fixado
+    return;
+  }
+  currentMode = 'auto';
+  prefs.scannerMode = 'auto';
+  savePrefs(prefs);
+  listeners.forEach((fn) => fn(currentMode));
+}
+
+export function onChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+

--- a/tests/descartes.spec.js
+++ b/tests/descartes.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import store, { setDescarte, selectDescartes } from '../src/store/index.js';
+
+beforeEach(() => {
+  store.state.conferidosByRZSku = {};
+  store.state.metaByRZSku = {};
+});
+
+describe('descartes', () => {
+  it('limits quantity and exports list', () => {
+    const id = 'RZ1:SKU1';
+    store.state.conferidosByRZSku['RZ1'] = { SKU1: { qtd: 5 } };
+    setDescarte(id, 10, 'muito');
+    expect(store.state.conferidosByRZSku['RZ1'].SKU1.qtd_descarte).toBe(5);
+    setDescarte(id, 3, 'ok');
+    const list = selectDescartes();
+    expect(list).toEqual([
+      { rz: 'RZ1', sku: 'SKU1', descricao: '', qtd_descartada: 3, obs: 'ok' }
+    ]);
+  });
+});

--- a/tests/excedente.spec.js
+++ b/tests/excedente.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { openExcedenteModal, getCurrentModal } from '../src/components/ExcedenteModal.js';
+
+describe('ExcedenteModal', () => {
+  it('accepts empty observation with Enter', async () => {
+    const promise = openExcedenteModal({ defaultValue: '' });
+    const modal = getCurrentModal();
+    modal.keypress('Enter');
+    const val = await promise;
+    expect(val).toBe('');
+  });
+
+  it('saves filled observation', async () => {
+    const promise = openExcedenteModal({ defaultValue: '' });
+    const modal = getCurrentModal();
+    modal.value = 'teste';
+    modal.keypress('Enter');
+    const val = await promise;
+    expect(val).toBe('teste');
+  });
+});

--- a/tests/scannerController.spec.js
+++ b/tests/scannerController.spec.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getMode, switchTo, afterRegister } from '../src/utils/scannerController.js';
+import { loadPrefs, savePrefs } from '../src/utils/prefs.js';
+
+beforeEach(() => {
+  localStorage.clear();
+  switchTo('auto');
+});
+
+describe('scannerController', () => {
+  it('switches mode and persists', () => {
+    switchTo('manual');
+    expect(getMode()).toBe('manual');
+    expect(loadPrefs().scannerMode).toBe('manual');
+  });
+
+  it('returns to auto after register unless locked', () => {
+    switchTo('manual');
+    let prefs = loadPrefs();
+    prefs.lockManualScanner = false;
+    savePrefs(prefs);
+    afterRegister();
+    expect(getMode()).toBe('auto');
+
+    switchTo('manual');
+    prefs = loadPrefs();
+    prefs.lockManualScanner = true;
+    savePrefs(prefs);
+    afterRegister();
+    expect(getMode()).toBe('manual');
+  });
+});


### PR DESCRIPTION
## Summary
- add UI preference helper with scanner settings
- implement scanner controller for auto/manual mode with persistence
- track excedente and descarte flags in store and expose export helpers
- provide basic excedente modal implementation
- cover new functionality with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f38ecf930832b8ec3dd2981602454