### PR TITLE
Default wedge scanner on desktop

### DIFF
--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -3,14 +3,7 @@ import { exportarConferencia } from '../utils/excel.js';
 import store, { findInRZ, findConferido, findEmOutrosRZ, moveItemEntreRZ, addExcedente } from '../store/index.js';
 import { loadFinanceConfig, saveFinanceConfig } from '../utils/finance.js';
 import { loadPrefs, savePrefs } from '../utils/prefs.js';
-
-function toast(msg, type='info') {
-  const el = document.createElement('div');
-  el.className = `toast ${type}`;
-  el.textContent = msg;
-  document.body.appendChild(el);
-  setTimeout(() => el.remove(), 2200);
-}
+import { toast } from '../utils/toast.js';
 
 function mostrarProdutoInfo(item) {
   const $ = (sel) => document.querySelector(sel);
@@ -50,6 +43,8 @@ export function initActionsPanel(render){
 
   btnCons?.classList.add('btn','btn-primary');
   btnReg?.classList.add('btn','btn-ghost');
+
+  inputSku?.focus();
 
   const cfg = loadFinanceConfig();
   const prefs = loadPrefs();
@@ -141,10 +136,14 @@ export function initActionsPanel(render){
     } catch(e) {
       console.error(e); toast('Falha ao registrar', 'error');
     }
+    inputSku?.focus();
   });
 
   inputSku?.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && e.ctrlKey) {
+      e.preventDefault();
+      btnReg?.click();
+    } else if (e.key === 'Enter') {
       e.preventDefault();
       btnCons?.click();
     }
@@ -205,7 +204,7 @@ export function initActionsPanel(render){
 
   document.addEventListener('keydown',(e)=>{
     if (e.ctrlKey && e.key.toLowerCase()==='k'){ e.preventDefault(); document.querySelector('#codigo-ml')?.focus(); }
-    if (e.ctrlKey && e.key === 'Enter'){ e.preventDefault(); btnReg?.click(); }
+    // Ctrl+Enter handled on inputSku for registro
     if (e.ctrlKey && e.key.toLowerCase()==='s'){
       const dlg = document.getElementById('dlg-excedente');
       if (dlg?.open) { e.preventDefault(); document.getElementById('exc-salvar')?.click(); }

--- a/src/components/ScannerPanel.js
+++ b/src/components/ScannerPanel.js
@@ -1,6 +1,7 @@
 // src/components/ScannerPanel.js
 import { iniciarLeitura, pararLeitura, listarCameras } from '../utils/scan.js';
 import { createCard } from './Card.js';
+import { isDesktop } from '../utils/platform.js';
 
 function setBoot(msg){
   const st = document.getElementById('boot-status');
@@ -12,6 +13,18 @@ export function initScannerPanel({ onCode }){
   const scannerCard = createCard('#card-scanner');
   const btnScan = document.getElementById('btn-scan-toggle');
   const videoEl = document.getElementById('preview');
+
+  if (isDesktop()) {
+    btnOpenScanner?.setAttribute('hidden', '');
+    btnScan?.setAttribute('hidden', '');
+    videoEl?.setAttribute('hidden', '');
+    const body = scannerCard.el.querySelector('.card-body');
+    if (body) {
+      body.innerHTML = '<p>Bipe ativo (USB)</p>';
+    }
+    setBoot('Bipe ativo (USB)');
+    return;
+  }
 
   videoEl?.setAttribute('hidden', '');
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,9 @@ import store from './store/index.js';
 import { loadFinanceConfig, loadMetricsPrefs, saveMetricsPrefs, computeItemFinance, computeAggregates } from './utils/finance.js';
 import { loadPrefs, savePrefs } from './utils/prefs.js';
 
-window.__DEBUG_SCAN__ = true;
+if (import.meta.env?.DEV) {
+  window.__DEBUG_SCAN__ = true;
+}
 
 function updateBoot(msg) {
   const el = document.getElementById('boot-status');

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -2,7 +2,7 @@ import * as XLSX from 'xlsx';
 import store from '../store/index.js';
 import { parseBRLLoose } from './number.js';
 
-const isDev = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV) || (typeof window !== 'undefined' && window.__DEBUG_SCAN__ === true);
+const isDev = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV);
 const DBG = (...a) => { if (isDev) console.log('[XLSX]', ...a); };
 
 const stripAccents = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/src/utils/platform.js
+++ b/src/utils/platform.js
@@ -1,0 +1,5 @@
+export function isMobile() {
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent || '' : '';
+  return /Android|iPhone|iPad|iPod/i.test(ua);
+}
+export function isDesktop() { return !isMobile(); }

--- a/src/utils/scannerController.js
+++ b/src/utils/scannerController.js
@@ -1,11 +1,12 @@
 import { loadPrefs, savePrefs } from './prefs.js';
+import { isDesktop } from './platform.js';
 
 let currentMode = 'wedge';
 const listeners = new Set();
 
 function init() {
   const prefs = loadPrefs();
-  currentMode = prefs.scannerMode || 'wedge';
+  currentMode = isDesktop() ? 'wedge' : (prefs.scannerMode || 'wedge');
 }
 
 init();
@@ -15,6 +16,7 @@ export function getMode() {
 }
 
 export function switchTo(mode = 'wedge') {
+  if (mode === 'camera' && isDesktop()) mode = 'wedge';
   currentMode = mode === 'camera' ? 'camera' : 'wedge';
   const prefs = loadPrefs();
   prefs.scannerMode = currentMode;

--- a/tests/scanner-fallback.spec.js
+++ b/tests/scanner-fallback.spec.js
@@ -20,11 +20,12 @@ let warnSpy;
 
 beforeEach(async () => {
   warnSpy = vi.spyOn(toast, 'warn').mockImplementation(() => {});
+  globalThis.window = { isSecureContext: true, navigator: { mediaDevices: {} } };
   const mod = await import('../src/utils/scan.js');
   iniciarLeitura = mod.iniciarLeitura;
 });
 
-describe.skip('scanner fallback', () => {
+describe('scanner fallback', () => {
   it('falls back to wedge on camera error', async () => {
     const video = {};
     await expect(iniciarLeitura(video, () => {})).rejects.toThrow();

--- a/tests/scannerController.spec.js
+++ b/tests/scannerController.spec.js
@@ -1,20 +1,36 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../src/utils/platform.js', () => ({
+  isDesktop: vi.fn(),
+  isMobile: vi.fn(),
+}));
+
 import { getMode, switchTo, afterRegister } from '../src/utils/scannerController.js';
 import { loadPrefs, savePrefs } from '../src/utils/prefs.js';
+import * as platform from '../src/utils/platform.js';
 
 beforeEach(() => {
   localStorage.clear();
+  platform.isDesktop.mockReturnValue(false);
   switchTo('wedge');
 });
 
 describe('scannerController', () => {
-  it('switches mode and persists', () => {
+  it('switches mode and persists on mobile', () => {
+    platform.isDesktop.mockReturnValue(false);
     switchTo('camera');
     expect(getMode()).toBe('camera');
     expect(loadPrefs().scannerMode).toBe('camera');
   });
 
+  it('ignores camera mode on desktop', () => {
+    platform.isDesktop.mockReturnValue(true);
+    switchTo('camera');
+    expect(getMode()).toBe('wedge');
+  });
+
   it('returns to auto after register unless locked', () => {
+    platform.isDesktop.mockReturnValue(false);
     switchTo('camera');
     let prefs = loadPrefs();
     prefs.lockScannerMode = false;


### PR DESCRIPTION
## Summary
- add platform detection utility
- default to wedge scanner on desktop and hide camera UI
- keep code field focused with toast centralization and shortcuts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f537b62a8832bb0b616e8b3105a03