### PR TITLE
feat: auto resolve NCM with queue and export tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,22 @@
           </div>
         </div>
       </section>
+      <section id="card-ncm" class="card">
+        <div class="card-header">
+          <h2>NCM</h2>
+          <div class="spacer"></div>
+          <label><input type="checkbox" id="ncm-only-fail" /> Somente falhas</label>
+        </div>
+        <div class="card-body">
+          <div id="ncm-progress" hidden>Resolvendo NCM… <span id="ncm-progress-count">0/0</span> <button id="ncm-cancel" class="btn ghost">Cancelar</button></div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>SKU</th><th>Descrição</th><th>NCM</th><th>Origem</th><th>Status</th></tr></thead>
+              <tbody id="ncm-table"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
 
       <section id="card-acoes" class="card">
         <div class="card-header">

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -159,15 +159,38 @@ export function initActionsPanel(render){
         const m = meta[sku] || {};
         const qtd = tot[sku] || 0;
         const preco = Number(m.precoMedio || 0);
-        return { SKU: sku, Descrição: m.descricao || '', Qtd: qtd, 'Preço Médio (R$)': preco, 'Valor Total (R$)': qtd*preco, Observação: confMap[sku]?.observacao || '' };
+        return {
+          SKU: sku,
+          Descrição: m.descricao || '',
+          Qtd: qtd,
+          'Preço Médio (R$)': preco,
+          'Valor Total (R$)': qtd * preco,
+          NCM: m.ncm || '',
+          Observação: confMap[sku]?.observacao || ''
+        };
       });
       const pendentes = Object.keys(tot).filter(sku => !confMap[sku]).map(sku => {
         const m = meta[sku] || {};
         const qtd = tot[sku] || 0;
         const preco = Number(m.precoMedio || 0);
-        return { SKU: sku, Descrição: m.descricao || '', Qtd: qtd, 'Preço Médio (R$)': preco, 'Valor Total (R$)': qtd*preco };
+        return {
+          SKU: sku,
+          Descrição: m.descricao || '',
+          Qtd: qtd,
+          'Preço Médio (R$)': preco,
+          'Valor Total (R$)': qtd * preco,
+          NCM: m.ncm || ''
+        };
       });
-      const excedentes = (store.state.excedentes[rz] || []).map(it=>({ SKU: it.sku, Descrição: it.descricao || '', Qtd: it.qtd, 'Preço Médio (R$)': Number(it.preco || 0), 'Valor Total (R$)': Number(it.qtd||0) * Number(it.preco||0), Observação: it.obs || '' }));
+      const excedentes = (store.state.excedentes[rz] || []).map(it => ({
+        SKU: it.sku,
+        Descrição: it.descricao || '',
+        Qtd: it.qtd,
+        'Preço Médio (R$)': Number(it.preco || 0),
+        'Valor Total (R$)': Number(it.qtd || 0) * Number(it.preco || 0),
+        NCM: it.ncm || '',
+        Observação: it.obs || ''
+      }));
 
       const sumQtd = arr => arr.reduce((s,it)=>s + Number(it.Qtd||0),0);
       const sumVal = arr => arr.reduce((s,it)=>s + Number(it['Valor Total (R$)']||0),0);

--- a/src/components/NcmPanel.js
+++ b/src/components/NcmPanel.js
@@ -1,0 +1,37 @@
+import store from '../store/index.js';
+
+export function initNcmPanel(){
+  const tbody = document.getElementById('ncm-table');
+  const progress = document.getElementById('ncm-progress');
+  const progressCount = document.getElementById('ncm-progress-count');
+  const cancelBtn = document.getElementById('ncm-cancel');
+  const chkFail = document.getElementById('ncm-only-fail');
+
+  cancelBtn?.addEventListener('click', ()=> document.dispatchEvent(new Event('ncm-cancel')));
+
+  document.addEventListener('ncm-progress', e=>{
+    const {done,total} = e.detail || {};
+    if(progress){
+      progress.hidden = done >= total;
+      if(progressCount) progressCount.textContent = `${done}/${total}`;
+    }
+  });
+
+  function render(){
+    const rows=[];
+    for(const metas of Object.values(store.state.metaByRZSku||{})){
+      for(const [sku, m] of Object.entries(metas||{})){
+        const status = m.ncm_status || '';
+        if(chkFail?.checked && status === 'ok') continue;
+        rows.push(`<tr><td>${sku}</td><td>${(m.descricao||'').slice(0,40)}</td><td>${m.ncm||''}</td><td>${m.ncm_source||''}</td><td>${status||''}</td></tr>`);
+      }
+    }
+    if(tbody) tbody.innerHTML = rows.join('');
+  }
+
+  chkFail?.addEventListener('change', render);
+  document.addEventListener('ncm-update', render);
+  render();
+}
+
+export default { initNcmPanel };

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -4,12 +4,14 @@ import { initImportPanel } from './ImportPanel.js';
 import { initActionsPanel } from './ActionsPanel.js';
 import { initScannerPanel } from './ScannerPanel.js';
 import { renderResults } from './ResultsPanel.js';
+import { initNcmPanel } from './NcmPanel.js';
 
 export function initApp(){
   const render = () => renderResults();
 
   const actions = initActionsPanel(render);
   initImportPanel(render);
+  initNcmPanel();
   initScannerPanel({
     onCode: (code) => {
       actions.setSku(code);

--- a/src/services/ncmService.js
+++ b/src/services/ncmService.js
@@ -36,7 +36,8 @@ export function createQueue(limit = 3){
   };
 }
 
-export async function resolveWithRetry(fn, attempts=3, baseDelay=100){
+// Retry helper with exponential backoff (default 2 retries: 500ms then 1s)
+export async function resolveWithRetry(fn, attempts=3, baseDelay=500){
   let lastErr;
   for(let i=0;i<attempts;i++){
     try{ return await fn(); }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -264,8 +264,11 @@ export function setItemNcm(id, ncm, source){
   if(!rz || !sku) return;
   (state.metaByRZSku[rz] ||= {});
   const meta = (state.metaByRZSku[rz][sku] ||= {});
+  const ts = Date.now();
   meta.ncm = ncm;
   meta.ncm_source = source;
+  meta.ncm_ts = ts;
+  meta.ncmMeta = { source, ts };
   meta.ncm_status = 'ok';
   state.ncmCache[sku] = ncm;
   try{ localStorage.setItem('ncmCache:v1', JSON.stringify(state.ncmCache)); }catch{}
@@ -315,6 +318,7 @@ export function selectAllImportedItems(){
         descricao: meta[sku]?.descricao || '',
         preco_ml_unit: Number(meta[sku]?.precoMedio || 0),
         qtd: Number(qtd || 0),
+        ncm: meta[sku]?.ncm || null,
       });
     }
   }

--- a/tests/export.spec.js
+++ b/tests/export.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as XLSX from 'xlsx';
+import { exportarConferencia } from '../src/utils/excel.js';
+
+describe('exportarConferencia', () => {
+  it('inclui coluna NCM', () => {
+    const spy = vi.spyOn(XLSX, 'writeFile').mockImplementation(() => {});
+    exportarConferencia({
+      conferidos:[{SKU:'1', Descrição:'Item', Qtd:1, 'Preço Médio (R$)':1, 'Valor Total (R$)':1, NCM:'12345678'}],
+      pendentes:[],
+      excedentes:[],
+      resumoRZ:[]
+    });
+    const wb = spy.mock.calls[0][0];
+    const sheet = wb.Sheets['Conferidos'];
+    const rows = XLSX.utils.sheet_to_json(sheet, { header:1 });
+    expect(rows[0]).toContain('NCM');
+    expect(rows[1][5]).toBe('12345678');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- resolve missing NCM codes via queued API lookups with retry and cache
- show resolution progress and cancellable NCM panel with failure filter
- include NCM data in store, exports and add coverage tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f55f88d10832b8d968dfc3c284942