### PR TITLE
feat: process NCM in background

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
           <div class="field">
             <label for="select-rz" class="label">RZ</label>
             <select id="select-rz" class="input"></select>
+            <span id="ncm-badge" class="badge" hidden>Resolvendo NCM… <span id="ncm-badge-count">0/0</span></span>
           </div>
         </div>
       </section>

--- a/src/services/ncmQueue.js
+++ b/src/services/ncmQueue.js
@@ -1,0 +1,53 @@
+import { resolve, resolveWithRetry } from './ncmService.js';
+import store, { setItemNcm, setItemNcmStatus } from '../store/index.js';
+
+function timeout(promise, ms){
+  return Promise.race([
+    promise,
+    new Promise((_,reject)=>setTimeout(()=>reject(new Error('timeout')), ms))
+  ]);
+}
+
+export async function startNcmQueue(items = []){
+  const pending = items
+    .filter(it => !it.ncm)
+    .map(it => ({ id: `${it.codigoRZ}:${it.codigoML}`, it }));
+
+  const total = pending.length;
+  let done = 0;
+  store.state.ncmState = { running: total > 0, done, total };
+  const hasDoc = typeof document !== 'undefined';
+  if(hasDoc) document.dispatchEvent(new CustomEvent('ncm-progress',{ detail:{ done, total } }));
+  if(!total) return;
+
+  const queue = pending.slice();
+  const workers = [];
+  const limit = 3;
+  async function worker(){
+    while(queue.length){
+      const { id, it } = queue.shift();
+      try{
+        setItemNcmStatus(id,'pendente');
+        const r = await resolveWithRetry(() => timeout(resolve({ sku: it.codigoML, ncmPlanilha: it.ncm, descricao: it.descricao }), 4000), 3, 500);
+        if(r.ok && r.ncm){
+          it.ncm = r.ncm;
+          setItemNcm(id, r.ncm, r.source);
+        }else{
+          setItemNcmStatus(id,'falha');
+        }
+      }catch{
+        setItemNcmStatus(id,'falha');
+      }finally{
+        done++;
+        store.state.ncmState = { running: true, done, total };
+        if(hasDoc) document.dispatchEvent(new CustomEvent('ncm-progress',{ detail:{ done, total } }));
+      }
+    }
+  }
+  for(let i=0;i<Math.min(limit,total);i++) workers.push(worker());
+  await Promise.all(workers);
+  store.state.ncmState = { running:false, done, total };
+  if(hasDoc) document.dispatchEvent(new CustomEvent('ncm-progress',{ detail:{ done, total } }));
+}
+
+export default { startNcmQueue };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -39,6 +39,8 @@ const state = {
     }
   })(),
 
+  ncmState: { running:false, done:0, total:0 },
+
   // tags livres por item (id -> Set)
   itemTags: {},
 };
@@ -55,6 +57,40 @@ function updateContadores(rz){
 export function setCurrentRZ(rz){
   state.currentRZ = state.rzAtual = rz;
   if (rz) updateContadores(rz);
+}
+
+export function setRZs(rzs = []){
+  state.rzList = Array.isArray(rzs) ? rzs : [];
+  if(!state.currentRZ) state.currentRZ = state.rzList[0] || null;
+  if(state.currentRZ) updateContadores(state.currentRZ);
+}
+
+export function setItens(items = []){
+  const itemsByRZ = {};
+  const totalByRZSku = {};
+  const metaByRZSku = {};
+  for(const it of items){
+    (itemsByRZ[it.codigoRZ] ||= []).push(it);
+    const sku = String(it.codigoML || '').trim().toUpperCase();
+    if(!sku) continue;
+    (totalByRZSku[it.codigoRZ] ||= {});
+    const inc = Number(it.qtd) || 0;
+    totalByRZSku[it.codigoRZ][sku] = (totalByRZSku[it.codigoRZ][sku] || 0) + inc;
+    (metaByRZSku[it.codigoRZ] ||= {});
+    if(!metaByRZSku[it.codigoRZ][sku]){
+      const descricao = String(it.descricao || '').trim();
+      const precoMedio = Number(it.valorUnit || 0);
+      const ncm = it.ncm || null;
+      metaByRZSku[it.codigoRZ][sku] = { descricao, precoMedio, ncm };
+    }
+  }
+  state.itemsByRZ = itemsByRZ;
+  state.totalByRZSku = totalByRZSku;
+  state.metaByRZSku = metaByRZSku;
+  state.conferidosByRZSku = {};
+  state.excedentes = {};
+  if(!state.currentRZ) state.currentRZ = Object.keys(itemsByRZ)[0] || null;
+  return { itemsByRZ, totalByRZSku, metaByRZSku };
 }
 
 export function addMovimento(m){ state.movimentos.push(m); }
@@ -325,6 +361,6 @@ export function selectAllImportedItems(){
   return items;
 }
 
-const store = { state, dispatch, getSkuInRZ, isConferido, findInRZ, findConferido, addExcedente, findEmOutrosRZ, moveItemEntreRZ, conferir, registrarExcedente, setItemNcm, setItemNcmStatus, tagItem, untagItem, selectAllItems, selectAllImportedItems, setExcedente, setDescarte, selectDescartes };
+const store = { state, dispatch, getSkuInRZ, isConferido, findInRZ, findConferido, addExcedente, findEmOutrosRZ, moveItemEntreRZ, conferir, registrarExcedente, setItemNcm, setItemNcmStatus, tagItem, untagItem, selectAllItems, selectAllImportedItems, setExcedente, setDescarte, selectDescartes, setRZs, setItens };
 
 export default store;


### PR DESCRIPTION
## Summary
- parse spreadsheet without awaiting NCM resolution
- run NCM resolution queue with concurrency, retries and timeout
- show NCM progress badge during import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f866f85f4832b996ba5a2726254dd