### PR TITLE
feat: track NCM resolution progress and metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,11 @@
       <section id="card-ncm" class="card">
         <div class="card-header">
           <h2>NCM</h2>
+          <div id="ncm-counters">
+            <span id="ncm-count-ok">0</span> OK /
+            <span id="ncm-count-fail">0</span> Falhas /
+            <span id="ncm-count-pend">0</span> Restantes
+          </div>
           <div class="spacer"></div>
           <label><input type="checkbox" id="ncm-only-fail" /> Somente falhas</label>
         </div>
@@ -57,6 +62,11 @@
               <thead><tr><th>SKU</th><th>Descrição</th><th>NCM</th><th>Origem</th><th>Status</th></tr></thead>
               <tbody id="ncm-table"></tbody>
             </table>
+          </div>
+          <div class="pager">
+            <button id="ncm-prev" class="btn ghost" type="button">&#171;</button>
+            <span id="ncm-page">0/0</span>
+            <button id="ncm-next" class="btn ghost" type="button">&#187;</button>
           </div>
         </div>
       </section>

--- a/tests/ncmQueue.spec.js
+++ b/tests/ncmQueue.spec.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import store from '../src/store/index.js';
+vi.mock('../src/services/ncmService.js', () => ({ resolve: vi.fn(), resolveWithRetry: vi.fn(fn => fn()) }));
+import { resolve as resolveMock, resolveWithRetry as resolveWithRetryMock } from '../src/services/ncmService.js';
+import { startNcmQueue } from '../src/services/ncmQueue.js';
+
+beforeEach(() => {
+  resolveMock.mockReset();
+  resolveWithRetryMock.mockReset().mockImplementation(fn => fn());
+  store.state.metaByRZSku = {};
+  store.state.itemsByRZ = {};
+  store.state.ncmState = { running:false, done:0, total:0 };
+});
+
+describe('ncmQueue', () => {
+  it('limits concurrency to 3', async () => {
+    let active = 0, max = 0;
+    resolveMock.mockImplementation(async () => {
+      active++;
+      max = Math.max(max, active);
+      await new Promise(res => setTimeout(() => { active--; res({ ok:true, ncm:'1', source:'api' }); }, 10));
+      return { ok:true, ncm:'1', source:'api' };
+    });
+    const items = Array.from({ length: 6 }, (_, i) => ({ codigoRZ:'RZ', codigoML:`S${i}`, descricao:'', ncm:null }));
+    await startNcmQueue(items);
+    expect(max).toBeLessThanOrEqual(3);
+  });
+
+  it('retries failed resolutions', async () => {
+    resolveMock
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValue({ ok:true, ncm:'12345678', source:'api' });
+    resolveWithRetryMock.mockImplementation(async fn => {
+      try { return await fn(); } catch { try { return await fn(); } catch { return await fn(); } }
+    });
+    const items = [{ codigoRZ:'RZ', codigoML:'SKU1', descricao:'', ncm:null }];
+    await startNcmQueue(items);
+    expect(resolveMock).toHaveBeenCalledTimes(3);
+    expect(store.state.metaByRZSku['RZ'].SKU1.ncm).toBe('12345678');
+  });
+
+  it('does not block synchronous code', async () => {
+    resolveMock.mockImplementation(() => new Promise(res => setTimeout(() => res({ ok:true, ncm:'1', source:'api' }), 10)));
+    const items = [{ codigoRZ:'RZ', codigoML:'A', descricao:'', ncm:null }];
+    let flag = false;
+    const p = startNcmQueue(items);
+    flag = true;
+    expect(flag).toBe(true);
+    await p;
+  });
+});

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import store, { totalPendentesCount, setItemNcm, setItemNcmStatus, selectAllItems } from '../src/store/index.js';
 
 describe('store state structure', () => {
@@ -25,25 +25,36 @@ describe('totalPendentesCount', () => {
 });
 
 describe('NCM helpers', () => {
+  beforeEach(() => {
+    store.state.metaByRZSku = {};
+    store.state.itemsByRZ = {};
+    localStorage.clear();
+  });
+
   it('setItemNcm saves data and cache', () => {
     const id = 'RZ1:SKU1';
     store.state.metaByRZSku['RZ1'] = { SKU1: { descricao: 'x' } };
+    store.state.itemsByRZ['RZ1'] = [{ codigoML: 'SKU1' }];
     setItemNcm(id, '12345678', 'api');
-    expect(store.state.metaByRZSku['RZ1'].SKU1).toMatchObject({ ncm: '12345678', ncm_source: 'api', ncm_status: 'ok' });
+    expect(store.state.metaByRZSku['RZ1'].SKU1).toMatchObject({ ncm: '12345678', ncm_source: 'api', ncm_status: 'ok', ncmMeta: { source:'api', status:'ok' } });
+    expect(store.state.itemsByRZ['RZ1'][0]).toMatchObject({ ncm: '12345678', ncmMeta: { source:'api', status:'ok' } });
     const cache = JSON.parse(localStorage.getItem('ncmCache:v1'));
     expect(cache).toHaveProperty('SKU1', '12345678');
   });
 
   it('setItemNcmStatus updates status', () => {
     const id = 'RZ1:SKU1';
-    setItemNcmStatus(id, 'pendente:api');
-    expect(store.state.metaByRZSku['RZ1'].SKU1.ncm_status).toBe('pendente:api');
+    store.state.metaByRZSku['RZ1'] = { SKU1: { descricao:'x' } };
+    store.state.itemsByRZ['RZ1'] = [{ codigoML:'SKU1' }];
+    setItemNcmStatus(id, 'pendente');
+    expect(store.state.metaByRZSku['RZ1'].SKU1.ncm_status).toBe('pendente');
+    expect(store.state.itemsByRZ['RZ1'][0].ncmMeta.status).toBe('pendente');
   });
 
   it('selectAllItems merges arrays', () => {
     store.state.currentRZ = 'RZ1';
     store.state.totalByRZSku['RZ1'] = { SKU1: 1, SKU2: 2 };
-    store.state.metaByRZSku['RZ1'].SKU2 = { descricao: 'y' };
+    store.state.metaByRZSku['RZ1'] = { SKU1:{ descricao:'x' }, SKU2: { descricao: 'y' } };
     store.state.excedentes['RZ1'] = [{ sku: 'EX1', descricao: 'z', qtd: 1 }];
     const all = selectAllItems();
     const ids = all.map(it => it.id);


### PR DESCRIPTION
## Summary
- show NCM resolution counters with paging and failure filter
- persist NCM metadata with source and status for each item
- add tests for NCM service, queue and import flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fbb754068832b872f32533cef99d3