### PR TITLE
feat: compact ncm panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
       <div class="indicators-grid"></div>
     </section>
 
-    <div class="layout-grid">
+    <div class="page">
+      <div class="main-col">
       <section id="card-importacao" class="card">
         <div class="card-header">
           <h2>Importação &amp; Seleção</h2>
@@ -33,8 +34,8 @@
           <div class="file-row">
             <label class="label" for="file">Planilha</label>
             <div class="file-input-wrap">
-              <input type="file" id="file" accept=".xlsx" />
-              <span id="file-name" class="ellipsis"></span>
+                <input type="file" id="file" accept=".xlsx" />
+                <span id="file-name" class="file-name"></span>
             </div>
           </div>
           <div class="field">
@@ -44,33 +45,6 @@
           </div>
         </div>
       </section>
-      <section id="card-ncm" class="card">
-        <div class="card-header">
-          <h2>NCM</h2>
-          <div id="ncm-counters">
-            <span id="ncm-count-ok">0</span> OK /
-            <span id="ncm-count-fail">0</span> Falhas /
-            <span id="ncm-count-pend">0</span> Restantes
-          </div>
-          <div class="spacer"></div>
-          <label><input type="checkbox" id="ncm-only-fail" /> Somente falhas</label>
-        </div>
-        <div class="card-body">
-          <div id="ncm-progress" hidden>Resolvendo NCM… <span id="ncm-progress-count">0/0</span> <button id="ncm-cancel" class="btn ghost">Cancelar</button></div>
-          <div class="table-wrap">
-            <table>
-              <thead><tr><th>SKU</th><th>Descrição</th><th>NCM</th><th>Origem</th><th>Status</th></tr></thead>
-              <tbody id="ncm-table"></tbody>
-            </table>
-          </div>
-          <div class="pager">
-            <button id="ncm-prev" class="btn ghost" type="button">&#171;</button>
-            <span id="ncm-page">0/0</span>
-            <button id="ncm-next" class="btn ghost" type="button">&#187;</button>
-          </div>
-        </div>
-      </section>
-
       <section id="card-acoes" class="card">
         <div class="card-header">
           <h2>Ações de Conferência</h2>
@@ -107,7 +81,7 @@
               </div>
               <div class="field">
                 <label class="label" for="btn-registrar">&nbsp;</label>
-                <button id="btn-registrar" class="btn btn-ghost" type="button">Registrar</button>
+                  <button id="btn-registrar" class="btn btn-primary" type="button">Registrar</button>
               </div>
             </div>
           </div>
@@ -294,8 +268,40 @@
           </section>
         </div>
       </section>
+      </div>
+      <section id="card-ncm" class="card collapsed">
+        <div class="card-header">
+          <h2>NCM</h2>
+          <div id="ncm-counters" class="chips">
+            <span id="ncm-count-ok" class="badge badge-ok">0 OK</span>
+            <span id="ncm-count-fail" class="badge badge-falha">0 Falhas</span>
+            <span id="ncm-count-pend" class="badge">0 Restantes</span>
+          </div>
+          <div class="spacer"></div>
+          <label><input type="checkbox" id="ncm-only-fail" checked /> Somente falhas</label>
+          <button id="ncm-collapse" class="btn ghost" type="button" title="Recolher/expandir">↕</button>
+        </div>
+        <div class="card-body">
+          <div id="ncm-progress" hidden>Resolvendo NCM… <span id="ncm-progress-count">0/0</span> <button id="ncm-cancel" class="btn ghost">Cancelar</button></div>
+          <div id="ncm-empty" hidden>
+            <p>Tudo certo! Nenhuma falha.</p>
+            <button id="ncm-show-all" class="btn ghost" type="button">Mostrar todos</button>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>SKU</th><th>Descrição</th><th>NCM</th><th>Origem</th><th>Status</th></tr></thead>
+              <tbody id="ncm-table"></tbody>
+            </table>
+          </div>
+          <div class="pager">
+            <button id="ncm-prev" class="btn ghost" type="button">&#171;</button>
+            <span id="ncm-page">0/0</span>
+            <button id="ncm-next" class="btn ghost" type="button">&#187;</button>
+          </div>
+        </div>
+      </section>
     </div>
-  </main>
+    </main>
 
     <div id="boot-status" aria-live="polite">
       <strong>Boot:</strong> aguardando…

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,22 +1,17 @@
 @import './css/style.css';
 
-/* Layout grid: 2 columns on desktop, 1 on mobile */
-.layout-grid {
+/* Page layout: main content + narrow NCM panel */
+.page {
   display: grid;
-  gap: var(--space-4);
+  grid-template-columns: 1fr 380px;
+  gap: 20px;
   max-width: 1200px;
   margin: var(--space-5) auto;
 }
-@media (min-width: 1024px) {
-  .layout-grid {
-    grid-template-columns: 1fr 1fr;
-  }
+@media (max-width: 1100px) {
+  .page { grid-template-columns: 1fr; }
 }
-@media (max-width: 1023px) {
-  .layout-grid {
-    grid-template-columns: 1fr;
-  }
-}
+.main-col { display:flex; flex-direction:column; gap:20px; }
 
 /* Scanner fechado: esconde tudo dentro do card */
 #card-scanner.collapsed .card-body { display: none; }
@@ -85,6 +80,9 @@ tr.avariado {
 .card { background:#fff; border:1px solid rgba(0,0,0,.08); border-radius:14px; padding:16px; box-shadow:0 2px 10px rgba(0,0,0,.06); }
 .card-header { display:flex; align-items:center; gap:12px; }
 .card .spacer { flex:1; }
+#card-ncm .table-wrap { max-height:70vh; overflow:auto; }
+#card-ncm th { position:sticky; top:0; background:#fff; }
+.chips { display:flex; gap:8px; }
 
 /* Botões */
 .btn { border-radius:10px; padding:10px 14px; border:1px solid transparent; cursor:pointer; }
@@ -98,12 +96,11 @@ tr.avariado {
 
 /* Financeiro colapsável */
 #finance-panel.collapsed .card-body { display:none; }
+#card-ncm.collapsed .card-body { display:none; }
 
 /* Nome do arquivo com ellipsis */
 .file-input-wrap { display:flex; gap:8px; align-items:center; max-width:100%; }
-#file-name.ellipsis {
-  flex:1; min-width:0; display:inline-block; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
-}
+.file-name { max-width:160px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 
 /* Inputs e selects */
 input[type="text"], input[type="number"], input[type="search"], .select, input[type="file"] {
@@ -118,7 +115,11 @@ input[type="text"], input[type="number"], input[type="search"], .select, input[t
 .row-pendente { background: #fff; }
 .row-conferido { background: #f0fff4; }
 .row-excedente { background: #fff7f7; }
+.row-ok { background: #f6ffed; }
+.row-falha { background: #fff1f0; }
 .badge { border-radius: 10px; padding: 2px 8px; font-size: 12px; }
 .badge-excedente { background:#ffe3e3; color:#b00020; }
 .badge-conferido { background:#dcfce7; color:#036d19; }
+.badge-ok { background:#dcfce7; color:#065f46; }
+.badge-falha { background:#fee2e2; color:#991b1b; }
 


### PR DESCRIPTION
## Summary
- arrange panels in two-column grid with narrow NCM sidebar
- add collapsible, paginated NCM panel that defaults to showing failures
- style table rows and badges for NCM status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fc9b20f68832b9e591387e473c456