### PR TITLE
feat: improve NCM resolution and queue

### DIFF
--- a/src/services/ncmService.js
+++ b/src/services/ncmService.js
@@ -2,17 +2,183 @@ import { RUNTIME } from '../config/runtime.js';
 
 const CACHE_KEY = 'ncmCache:v1';
 const mem = new Map();
-let ncmMapCache;
+const prom = new Map();
+let mapPromise;
 
-function log(term, source, hit){
+const STOPWORDS = new Set(['de','do','da','para','com','a','o','e','em','no','na','dos','das']);
+
+function log(term, step, result, ms){
   if(import.meta.env?.DEV){
-    console.debug('[NCM]', { term, source, hit });
+    console.debug('[NCM]', { term, step, result, ms });
   }
 }
 
 export function normalizeNCM(n){
-  const d = String(n ?? '').replace(/\D/g, '');
+  const d = String(n ?? '').replace(/\D/g,'');
   return /^\d{8}$/.test(d) ? d : null;
+}
+
+function slug(s){
+  return String(s||'').toLowerCase()
+    .normalize('NFD').replace(/[\u0300-\u036f]/g,'')
+    .replace(/[^\w\s]+/g,' ')
+    .replace(/\s+/g,' ')
+    .trim();
+}
+
+function keywords(s){
+  return slug(s).split(' ').filter(w => w && !STOPWORDS.has(w));
+}
+
+function cacheGet(k){
+  if(mem.has(k)) return mem.get(k);
+  try{
+    const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+    const v = raw[k];
+    if(v){ mem.set(k,v); return v; }
+  }catch{}
+  return null;
+}
+
+function cacheSet(k,v){
+  mem.set(k,v);
+  try{
+    const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
+    raw[k] = v;
+    localStorage.setItem(CACHE_KEY, JSON.stringify(raw));
+  }catch{}
+}
+
+async function fetchLocalMap(){
+  if(!mapPromise){
+    mapPromise = fetch(RUNTIME.NCM_LOCAL_MAP_URL)
+      .then(r=>r.ok?r.json():{})
+      .then(m=>{
+        const out={};
+        for(const [k,v] of Object.entries(m||{})) out[slug(k)]=v;
+        return out;
+      })
+      .catch(()=>({}));
+  }
+  return mapPromise;
+}
+
+async function fetchAPI(term){
+  const isCode = /^\d{8}$/.test(term);
+  const q = isCode ? `codigo=${encodeURIComponent(term)}` : `descricao=${encodeURIComponent(term)}`;
+  const kw = isCode ? [] : keywords(term);
+
+  const attempt = async () => {
+    const controller = new AbortController();
+    const t = setTimeout(()=>controller.abort(),4000);
+    try{
+      const resp = await fetch(`/api/ncm?${q}`, { signal: controller.signal });
+      if(!resp.ok){
+        const err = new Error('http '+resp.status);
+        if(resp.status >= 500) err.retry = true;
+        throw err;
+      }
+      const data = await resp.json();
+      const list = Array.isArray(data)?data:[data];
+      if(isCode){
+        const code = normalizeNCM(term);
+        const found = list.find(it => normalizeNCM(it.codigoNcm||it.codigo) === code);
+        return { ncm: found?code:null, raw:data };
+      }else{
+        let best=null, bestScore=0;
+        for(const it of list){
+          const code = normalizeNCM(it.codigoNcm||it.codigo);
+          if(!code) continue;
+          const dkw = keywords(it.descricao||'');
+          const score = kw.reduce((a,k)=>a + (dkw.includes(k)?1:0),0);
+          if(score >= 2 && score > bestScore){
+            best = { ncm:code, raw:it, score };
+            bestScore = score;
+          }
+        }
+        return { ncm: best?best.ncm:null, raw:data };
+      }
+    } finally {
+      clearTimeout(t);
+    }
+  };
+
+  for(let i=0;i<3;i++){
+    try{
+      return await attempt();
+    }catch(err){
+      if(!err.retry || i===2) throw err;
+      await new Promise(r=>setTimeout(r,500*(i+1)));
+    }
+  }
+}
+
+async function resolveTermInternal(term, key, { onlyCache=false }={}){
+  const start = (performance.now?performance.now():Date.now());
+  const cached = cacheGet(key);
+  if(cached){
+    const ms = (performance.now?performance.now():Date.now())-start;
+    log(term,'cache','hit',ms);
+    return { ncm: cached.ncm, source:'cache', status:'ok' };
+  }
+
+  const map = await fetchLocalMap();
+  const mapped = map[key];
+  const local = normalizeNCM(mapped);
+  if(local){
+    const val = { ncm:local, source:'map', ts:Date.now() };
+    cacheSet(key,val);
+    const ms = (performance.now?performance.now():Date.now())-start;
+    log(term,'map','hit',ms);
+    return { ncm:local, source:'map', status:'ok' };
+  }
+
+  if(onlyCache){
+    const ms = (performance.now?performance.now():Date.now())-start;
+    log(term,'cache','miss',ms);
+    return { ncm:null, source:'cache', status:'falha' };
+  }
+
+  try{
+    const { ncm, raw } = await fetchAPI(term);
+    const ms = (performance.now?performance.now():Date.now())-start;
+    if(ncm){
+      const val = { ncm, source:'api', ts:Date.now() };
+      cacheSet(key,val);
+      log(term,'api','hit',ms);
+      return { ncm, source:'api', status:'ok', raw };
+    }
+    log(term,'api','miss',ms);
+    return { ncm:null, source:'api', status:'falha', raw };
+  }catch{
+    const ms = (performance.now?performance.now():Date.now())-start;
+    log(term,'api','err',ms);
+    return { ncm:null, source:'api', status:'falha' };
+  }
+}
+
+async function resolveTerm(term, opts={}){
+  const key = slug(term);
+  if(prom.has(key)) return prom.get(key);
+  const p = resolveTermInternal(term, key, opts).finally(()=>prom.delete(key));
+  prom.set(key,p);
+  return p;
+}
+
+export async function resolve(input){
+  if(typeof input === 'string'){
+    return resolveTerm(input);
+  }
+  const sku = input?.sku;
+  const descricao = input?.descricao;
+  if(sku){
+    const r = await resolveTerm(sku, { onlyCache:true });
+    if(r.status === 'ok') return r;
+  }
+  if(descricao){
+    return resolveTerm(descricao);
+  }
+  return { ncm:null, source:'cache', status:'falha' };
 }
 
 export function createQueue(limit = 3){
@@ -38,100 +204,13 @@ export async function resolveWithRetry(fn, attempts=3, baseDelay=500){
   throw lastErr;
 }
 
-function slug(s){
-  return String(s||'').toLowerCase()
-    .normalize('NFD').replace(/[^\w]+/g,'').replace(/\s+/g,'')
-    .replace(/[\u0300-\u036f]/g,'');
+export function __reset(){
+  mem.clear();
+  prom.clear();
+  mapPromise = null;
 }
 
-function cacheGet(k){
-  if(mem.has(k)) return mem.get(k);
-  try{
-    const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
-    const v = raw[k];
-    if(v){ mem.set(k,v); return v; }
-  }catch{}
-  return null;
-}
+export { cacheGet, cacheSet, slug, keywords };
 
-function cacheSet(k,v){
-  mem.set(k,v);
-  try{
-    const raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}');
-    raw[k] = v;
-    localStorage.setItem(CACHE_KEY, JSON.stringify(raw));
-  }catch{}
-}
+export default { normalizeNCM, resolve, resolveWithRetry, createQueue };
 
-async function fetchLocalMap(){
-  if(!ncmMapCache){
-    ncmMapCache = fetch(RUNTIME.NCM_LOCAL_MAP_URL)
-      .then(r=>r.ok?r.json():{})
-      .catch(()=>({}));
-  }
-  return ncmMapCache;
-}
-
-async function fetchFromAPI(term){
-  const isCode = /^\d{8}$/.test(term);
-  const q = isCode ? `codigo=${encodeURIComponent(term)}` : `descricao=${encodeURIComponent(term)}`;
-  const controller = new AbortController();
-  const t = setTimeout(()=>controller.abort(), 4000);
-  try{
-    const r = await fetch(`/api/ncm?${q}`, { signal: controller.signal });
-    if(!r.ok) throw new Error('http');
-    const data = await r.json();
-    const list = Array.isArray(data) ? data : [data];
-    const key = slug(term);
-    let best = null, score = -1;
-    for(const it of list){
-      const code = normalizeNCM(it.codigoNcm || it.codigo);
-      const desc = slug(it.descricao || '');
-      const s = (code && code.length===8 ? 1 : 0) + (key && desc.includes(key) ? 1 : 0);
-      if(s > score){ score = s; best = code; }
-    }
-    return best;
-  } finally {
-    clearTimeout(t);
-  }
-}
-
-export async function resolve({ sku, ncmPlanilha, descricao }){
-  const term = sku;
-  const direct = normalizeNCM(ncmPlanilha);
-  if(direct){ cacheSet(term,direct); log(term,'row',true); return { ok:true, ncm:direct, source:'row' }; }
-
-  const cached = cacheGet(term);
-  if(cached){ log(term,'cache',true); return { ok:true, ncm:cached, source:'cache' }; }
-
-  const map = await fetchLocalMap();
-  const slugDesc = slug(descricao);
-  const mapped = map[term] || map[slugDesc];
-  const local = normalizeNCM(mapped);
-  if(local){ cacheSet(term, local); log(term,'map',true); return { ok:true, ncm:local, source:'map' }; }
-
-  try{
-    const api = await fetchFromAPI(descricao || term);
-    if(api){ cacheSet(term, api); log(term,'api',true); return { ok:true, ncm:api, source:'api' }; }
-    log(term,'api',false);
-    return { ok:false, ncm:null, source:'api', error:true };
-  }catch{
-    log(term,'api',false);
-    return { ok:false, ncm:null, source:'api', error:true };
-  }
-}
-
-const enqueue = createQueue(3);
-
-export function resolveQueued(args){
-  return enqueue(()=>resolve(args));
-}
-
-export async function resolveNCM(args){
-  const r = await resolve(args);
-  return r.ok ? r.ncm : null;
-}
-
-export { cacheGet, cacheSet, slug };
-
-export default { normalizeNCM, resolve, resolveQueued, resolveNCM };

--- a/tests/ncmQueue.spec.js
+++ b/tests/ncmQueue.spec.js
@@ -18,8 +18,8 @@ describe('ncmQueue', () => {
     resolveMock.mockImplementation(async () => {
       active++;
       max = Math.max(max, active);
-      await new Promise(res => setTimeout(() => { active--; res({ ok:true, ncm:'1', source:'api' }); }, 10));
-      return { ok:true, ncm:'1', source:'api' };
+      await new Promise(res => setTimeout(() => { active--; res({ status:'ok', ncm:'1', source:'api' }); }, 10));
+      return { status:'ok', ncm:'1', source:'api' };
     });
     const items = Array.from({ length: 6 }, (_, i) => ({ codigoRZ:'RZ', codigoML:`S${i}`, descricao:'', ncm:null }));
     await startNcmQueue(items);
@@ -30,7 +30,7 @@ describe('ncmQueue', () => {
     resolveMock
       .mockRejectedValueOnce(new Error('fail1'))
       .mockRejectedValueOnce(new Error('fail2'))
-      .mockResolvedValue({ ok:true, ncm:'12345678', source:'api' });
+      .mockResolvedValue({ status:'ok', ncm:'12345678', source:'api' });
     resolveWithRetryMock.mockImplementation(async fn => {
       try { return await fn(); } catch { try { return await fn(); } catch { return await fn(); } }
     });
@@ -41,7 +41,7 @@ describe('ncmQueue', () => {
   });
 
   it('does not block synchronous code', async () => {
-    resolveMock.mockImplementation(() => new Promise(res => setTimeout(() => res({ ok:true, ncm:'1', source:'api' }), 10)));
+    resolveMock.mockImplementation(() => new Promise(res => setTimeout(() => res({ status:'ok', ncm:'1', source:'api' }), 10)));
     const items = [{ codigoRZ:'RZ', codigoML:'A', descricao:'', ncm:null }];
     let flag = false;
     const p = startNcmQueue(items);


### PR DESCRIPTION
## Summary
- add in-memory and persistent cache with local map and API fallback
- ensure single in-flight NCM lookups with heuristics and retry logic
- add circuit breaker and pause handling to NCM queue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fce308384832ba2a0f47a1136901e