### PR TITLE
feat: streamline wedge scanning and excedente flow

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -14,6 +14,7 @@ body{background:var(--bg); color:#0f172a; font:400 15px/1.45 system-ui,-apple-sy
 .btn-primary:hover{background:var(--primary-600)}
 .btn-primary:active{background:var(--primary-700)}
 .btn-ghost{background:transparent; color:var(--muted)}
+.btn.loading{opacity:.6;pointer-events:none}
 input,select{height:44px; border-radius:12px; border:1px solid #e5e7eb; padding:0 12px}
 input:focus,select:focus{outline:3px solid rgba(37,99,235,.2); border-color:var(--primary)}
 .badge{border-radius:999px; padding:2px 10px; font-size:12px}

--- a/src/utils/scannerController.js
+++ b/src/utils/scannerController.js
@@ -30,10 +30,12 @@ export function switchTo(mode = 'wedge') {
 
 export function afterRegister() {
   const prefs = loadPrefs();
-  if (prefs.lockScannerMode) {
-    return;
+  if (!prefs.lockScannerMode) {
+    switchTo('wedge');
   }
-  switchTo('wedge');
+  const el = document.getElementById('codigo-produto') || document.querySelector('input[placeholder="Código do produto"]');
+  el?.focus?.();
+  if (currentMode === 'wedge') el?.select?.();
 }
 
 export function onChange(fn) {

--- a/tests/actions-enter-flow.spec.js
+++ b/tests/actions-enter-flow.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initActionsPanel } from '../src/components/ActionsPanel.js';
+
+let input, btnCons, btnReg;
+
+describe('enter flow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const elements = {};
+    function createEl(tag='input') {
+      const el = {
+        tagName: tag.toUpperCase(),
+        value: '',
+        classList: { add: () => {}, remove: () => {} },
+        focus() { document.activeElement = this; },
+        select() {},
+        addEventListener(type, fn) { (el._l ||= {})[type] = fn; },
+        click() { el._l?.click?.({}); },
+        dispatchEvent(ev) { el._l?.[ev.type]?.(ev); },
+        setAttribute: () => {},
+        removeAttribute: () => {},
+      };
+      return el;
+    }
+    elements['codigo-produto'] = createEl('input');
+    elements['btn-consultar'] = createEl('button');
+    elements['btn-registrar'] = createEl('button');
+    elements['obs-preset'] = createEl('select');
+    elements['preco-ajustado'] = createEl('input');
+
+    global.document = {
+      body: { appendChild: () => {} },
+      activeElement: null,
+      getElementById: (id) => elements[id] || null,
+      querySelector: (sel) => elements[sel.replace('#','')] || null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      createElement: () => ({ className:'', setAttribute:()=>{}, textContent:'', remove:()=>{} }),
+    };
+    global.window = { refreshIndicators: () => {}, scrollTo: () => {} };
+    global.localStorage = { _s:{}, getItem(k){return this._s[k]||null;}, setItem(k,v){this._s[k]=String(v);}, removeItem(k){delete this._s[k];}, clear(){this._s={};} };
+    initActionsPanel(() => {});
+    input = elements['codigo-produto'];
+    btnCons = elements['btn-consultar'];
+    btnReg = elements['btn-registrar'];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('Enter on code field triggers Consultar', () => {
+    const spy = vi.fn();
+    btnCons.addEventListener('click', spy);
+    input.dispatchEvent({ type:'keydown', key:'Enter', preventDefault: () => {} });
+    vi.runAllTimers();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Ctrl+Enter triggers Registrar', () => {
+    const spy = vi.fn();
+    btnReg.addEventListener('click', spy);
+    input.dispatchEvent({ type:'keydown', key:'Enter', ctrlKey:true, preventDefault: () => {} });
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/actions-excedente.spec.js
+++ b/tests/actions-excedente.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initActionsPanel } from '../src/components/ActionsPanel.js';
+import store from '../src/store/index.js';
+
+describe('actions excedente', () => {
+  let input, btnReg, obsSelect, preco;
+
+  beforeEach(() => {
+    const elements = {};
+    function createEl(tag='input') {
+      const el = {
+        tagName: tag.toUpperCase(),
+        value: '',
+        classList: { add: () => {}, remove: () => {} },
+        focus() { document.activeElement = this; },
+        select() {},
+        addEventListener(type, fn) { (el._l ||= {})[type] = fn; },
+        click() { el._l?.click?.({}); },
+        dispatchEvent(ev) { el._l?.[ev.type]?.(ev); },
+        setAttribute: () => {},
+        removeAttribute: () => {},
+      };
+      return el;
+    }
+    elements['codigo-produto'] = createEl('input');
+    elements['btn-consultar'] = createEl('button');
+    elements['btn-registrar'] = createEl('button');
+    elements['obs-preset'] = createEl('select');
+    elements['preco-ajustado'] = createEl('input');
+
+    global.document = {
+      body: { appendChild: () => {} },
+      activeElement: null,
+      getElementById: (id) => elements[id] || null,
+      querySelector: (sel) => elements[sel.replace('#','')] || null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      createElement: () => ({ className:'', setAttribute:()=>{}, textContent:'', remove:()=>{} }),
+    };
+    global.window = { refreshIndicators: () => {}, scrollTo: () => {} };
+    global.localStorage = { _s:{}, getItem(k){return this._s[k]||null;}, setItem(k,v){this._s[k]=String(v);}, removeItem(k){delete this._s[k];}, clear(){this._s={};} };
+    store.state.rzAtual = 'R1';
+    store.state.excedentes = {};
+    initActionsPanel(() => {});
+    input = elements['codigo-produto'];
+    btnReg = elements['btn-registrar'];
+    obsSelect = elements['obs-preset'];
+    preco = elements['preco-ajustado'];
+  });
+
+  it('registers excedente without price', () => {
+    input.value = 'ABC';
+    obsSelect.value = 'excedente';
+    preco.value = '';
+    btnReg.click();
+    const exc = store.state.excedentes['R1'][0];
+    expect(exc.preco).toBeUndefined();
+    expect(obsSelect.value).toBe('');
+    expect(preco.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('registers excedente with price', () => {
+    input.value = 'XYZ';
+    obsSelect.value = 'excedente';
+    preco.value = '10';
+    btnReg.click();
+    const exc = store.state.excedentes['R1'][0];
+    expect(exc.preco).toBe(10);
+  });
+});

--- a/tests/scannerController.spec.js
+++ b/tests/scannerController.spec.js
@@ -13,9 +13,17 @@ beforeEach(() => {
   localStorage.clear();
   platform.isDesktop.mockReturnValue(false);
   switchTo('wedge');
+  global.document = { getElementById: () => null, querySelector: () => null };
 });
 
 describe('scannerController', () => {
+  it('defaults to wedge mode on desktop', async () => {
+    platform.isDesktop.mockReturnValue(true);
+    vi.resetModules();
+    const sc = await import('../src/utils/scannerController.js');
+    expect(sc.getMode()).toBe('wedge');
+  });
+
   it('switches mode and persists on mobile', () => {
     platform.isDesktop.mockReturnValue(false);
     switchTo('camera');
@@ -44,5 +52,12 @@ describe('scannerController', () => {
     savePrefs(prefs);
     afterRegister();
     expect(getMode()).toBe('camera');
+  });
+
+  it('afterRegister focuses code input', () => {
+    const el = { focus: vi.fn(), select: vi.fn() };
+    global.document = { getElementById: () => el, querySelector: () => el };
+    afterRegister();
+    expect(el.focus).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow registering "Excedente" items without a price while requiring it for others
- improve wedge scanner input normalization and shortcut handling
- add tests for excedente registration and keyboard flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a119ad9ae4832baf961c18f1702d17