### PR TITLE
feat: improve scanner and focus behaviour

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,8 @@
           <div class="actions-grid">
             <div class="row">
               <div class="field">
-                <label for="codigo-ml" class="label">Código do produto</label>
-                <input type="text" id="codigo-ml" placeholder="Código do produto" class="input" />
+                <label for="input-codigo-produto" class="label">Código do produto</label>
+                <input type="text" id="input-codigo-produto" placeholder="Código do produto" class="input" />
               </div>
               <div class="field">
                 <label class="label" for="btn-consultar">&nbsp;</label>

--- a/src/components/ImportPanel.js
+++ b/src/components/ImportPanel.js
@@ -36,7 +36,12 @@ export function initImportPanel(render){
     render?.();
   });
 
-  rzSelect?.addEventListener('change', e=>{ setCurrentRZ(e.target.value || null); render?.(); });
+  rzSelect?.addEventListener('change', e=>{
+    setCurrentRZ(e.target.value || null);
+    render?.();
+    const input = document.querySelector('#input-codigo-produto');
+    if (input) { input.focus(); input.select(); }
+  });
 
   const badge = document.getElementById('ncm-badge');
   const badgeCount = document.getElementById('ncm-badge-count');

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -15,7 +15,7 @@ export function initApp(){
   initScannerPanel({
     onCode: (code) => {
       actions.setSku(code);
-      actions.consultar('scanner');
+      actions.handleConsultar('scanner');
     }
   });
 

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -10,7 +10,7 @@ const DEFAULT_PREFS = {
   showIndicators: false,
   calcFreteMode: 'finalizar',
   scannerMode: 'wedge',      // 'wedge' | 'camera'
-  lockScannerMode: true,
+  lockScannerMode: false,
   autoRegisterOnSecondEnter: false,
   predefineExcedente: false,
   askDiscardOnFinalize: true,

--- a/src/utils/scannerController.js
+++ b/src/utils/scannerController.js
@@ -34,7 +34,7 @@ export function afterRegister() {
   if (!prefs.lockScannerMode) {
     switchTo('wedge');
   }
-  const el = document.getElementById('codigo-produto') || document.querySelector('input[placeholder="Código do produto"]');
+  const el = document.getElementById('input-codigo-produto') || document.querySelector('input[placeholder="Código do produto"]');
   el?.focus?.();
   if (currentMode === 'wedge') el?.select?.();
 }

--- a/tests/actions-excedente.spec.js
+++ b/tests/actions-excedente.spec.js
@@ -22,7 +22,7 @@ describe('actions excedente', () => {
       };
       return el;
     }
-    elements['codigo-produto'] = createEl('input');
+    elements['input-codigo-produto'] = createEl('input');
     elements['btn-consultar'] = createEl('button');
     elements['btn-registrar'] = createEl('button');
     elements['obs-preset'] = createEl('select');
@@ -42,7 +42,7 @@ describe('actions excedente', () => {
     store.state.rzAtual = 'R1';
     store.state.excedentes = {};
     initActionsPanel(() => {});
-    input = elements['codigo-produto'];
+    input = elements['input-codigo-produto'];
     btnReg = elements['btn-registrar'];
     obsSelect = elements['obs-preset'];
     preco = elements['preco-ajustado'];

--- a/tests/actions-flow.spec.js
+++ b/tests/actions-flow.spec.js
@@ -3,7 +3,7 @@ import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 
 let elements;
-let input, btnCons, btnReg, obsSelect, preco;
+let input, btnCons, btnReg, obsSelect, preco, actions;
 
 function createEl(tag = 'input') {
   const el = {
@@ -22,13 +22,20 @@ function createEl(tag = 'input') {
 }
 
 beforeEach(() => {
-  vi.useFakeTimers();
   elements = {};
-  elements['codigo-produto'] = createEl('input');
+  elements['input-codigo-produto'] = createEl('input');
   elements['btn-consultar'] = createEl('button');
   elements['btn-registrar'] = createEl('button');
   elements['obs-preset'] = createEl('select');
   elements['preco-ajustado'] = createEl('input');
+  elements['pi-sku'] = { textContent: '' };
+  elements['pi-desc'] = { textContent: '' };
+  elements['pi-qtd'] = { textContent: '' };
+  elements['pi-preco'] = { textContent: '' };
+  elements['pi-total'] = { textContent: '' };
+  elements['pi-rz'] = { textContent: '' };
+  elements['pi-ncm'] = { textContent: '' };
+  elements['produto-info'] = { hidden: false };
 
   global.document = {
     body: { appendChild: () => {} },
@@ -47,17 +54,15 @@ beforeEach(() => {
   store.state.conferidosByRZSku = {};
   store.state.excedentes = {};
 
-  initActionsPanel(() => {});
-  input = elements['codigo-produto'];
+  actions = initActionsPanel(() => {});
+  input = elements['input-codigo-produto'];
   btnCons = elements['btn-consultar'];
   btnReg = elements['btn-registrar'];
   obsSelect = elements['obs-preset'];
   preco = elements['preco-ajustado'];
 });
 
-afterEach(() => {
-  vi.useRealTimers();
-});
+afterEach(() => {});
 
 describe('actions flow', () => {
   it('focus returns to code after register', () => {
@@ -86,12 +91,11 @@ describe('actions flow', () => {
   });
 
   it('Enter consults and Ctrl+Enter registers', () => {
-    const consSpy = vi.fn();
-    const regSpy = vi.fn();
-    btnCons.addEventListener('click', consSpy);
-    btnReg.addEventListener('click', regSpy);
+    const consSpy = vi.spyOn(store, 'findInRZ');
+    const regSpy = vi.spyOn(store, 'conferir');
+    input.value = 'ABC';
+    preco.value = '5';
     input.dispatchEvent({ type: 'keydown', key: 'Enter', preventDefault: () => {} });
-    vi.runAllTimers();
     input.dispatchEvent({ type: 'keydown', key: 'Enter', ctrlKey: true, preventDefault: () => {} });
     expect(consSpy).toHaveBeenCalled();
     expect(regSpy).toHaveBeenCalled();

--- a/tests/actions-focus.spec.js
+++ b/tests/actions-focus.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initActionsPanel } from '../src/components/ActionsPanel.js';
+import { initImportPanel } from '../src/components/ImportPanel.js';
+import store from '../src/store/index.js';
+
+let elements, actions, input, rzSelect;
+
+function createEl(tag = 'input') {
+  const el = {
+    tagName: tag.toUpperCase(),
+    value: '',
+    classList: { add: () => {}, remove: () => {} },
+    focus() { document.activeElement = this; },
+    select() { this._selected = true; },
+    addEventListener(type, fn) { (el._l ||= {})[type] = fn; },
+    click() { el._l?.click?.({}); },
+    dispatchEvent(ev) { el._l?.[ev.type]?.(ev); },
+    setAttribute: () => {},
+    removeAttribute: () => {},
+  };
+  return el;
+}
+
+describe('focus management', () => {
+  beforeEach(() => {
+    elements = {};
+    elements['input-codigo-produto'] = createEl('input');
+    elements['btn-consultar'] = createEl('button');
+    elements['btn-registrar'] = createEl('button');
+    elements['obs-preset'] = createEl('select');
+    elements['preco-ajustado'] = createEl('input');
+    elements['select-rz'] = createEl('select');
+    elements['pi-sku'] = { textContent: '' };
+    elements['pi-desc'] = { textContent: '' };
+    elements['pi-qtd'] = { textContent: '' };
+    elements['pi-preco'] = { textContent: '' };
+    elements['pi-total'] = { textContent: '' };
+    elements['pi-rz'] = { textContent: '' };
+    elements['pi-ncm'] = { textContent: '' };
+    elements['produto-info'] = { hidden: false };
+
+    global.document = {
+      body: { appendChild: () => {} },
+      activeElement: null,
+      getElementById: (id) => elements[id] || null,
+      querySelector: (sel) => elements[sel.replace('#', '')] || null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      createElement: () => ({ className: '', setAttribute: () => {}, textContent: '', remove: () => {} }),
+    };
+    global.window = { refreshIndicators: () => {}, scrollTo: () => {} };
+    global.localStorage = { _s:{}, getItem(k){return this._s[k]||null;}, setItem(k,v){this._s[k]=String(v);}, removeItem(k){delete this._s[k];}, clear(){this._s={};} };
+
+    store.state.rzAtual = 'R1';
+    store.state.excedentes = {};
+
+    actions = initActionsPanel(() => {});
+    initImportPanel(() => {});
+    input = elements['input-codigo-produto'];
+    rzSelect = elements['select-rz'];
+  });
+
+  it('focuses code input after RZ change', () => {
+    rzSelect.value = 'R2';
+    rzSelect.dispatchEvent({ type:'change', target: rzSelect });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('returns focus and selection after handleRegistrar', async () => {
+    store.findInRZ = () => ({ qtd:1, precoMedio:10 });
+    store.conferir = vi.fn();
+    input.value = 'ABC';
+    elements['preco-ajustado'].value = '5';
+    await actions.handleRegistrar();
+    expect(document.activeElement).toBe(input);
+    expect(input._selected).toBe(true);
+  });
+
+  it('keyboard shortcuts trigger handlers', () => {
+    const consSpy = vi.spyOn(store, 'findInRZ').mockReturnValue({ qtd:1, precoMedio:10 });
+    const regSpy = vi.spyOn(store, 'conferir').mockImplementation(() => {});
+    input.value = 'AAA';
+    elements['preco-ajustado'].value = '1';
+    input.dispatchEvent({ type:'keydown', key:'Enter', preventDefault: () => {} });
+    input.dispatchEvent({ type:'keydown', key:'Enter', ctrlKey:true, preventDefault: () => {} });
+    expect(consSpy).toHaveBeenCalled();
+    expect(regSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/actions-panel.spec.js
+++ b/tests/actions-panel.spec.js
@@ -23,7 +23,7 @@ describe('ActionsPanel behaviors', () => {
       };
       return el;
     }
-    elements['codigo-produto'] = createEl('input');
+    elements['input-codigo-produto'] = createEl('input');
     elements['btn-consultar'] = createEl('button');
     elements['obs-preset'] = createEl('select');
     elements['preco-ajustado'] = createEl('input');
@@ -47,7 +47,7 @@ describe('ActionsPanel behaviors', () => {
     store.state.rzAtual = 'R1';
     store.state.excedentes = {};
     initActionsPanel(()=>{});
-    input = elements['codigo-produto'];
+    input = elements['input-codigo-produto'];
     btnCons = elements['btn-consultar'];
     btnReg = elements['btn-registrar'];
     obsSelect = elements['obs-preset'];

--- a/tests/scannerController.spec.js
+++ b/tests/scannerController.spec.js
@@ -69,6 +69,7 @@ describe('attachWedgeCapture', () => {
 
   beforeEach(() => {
     localStorage.clear();
+    localStorage.setItem('ui:prefs:v3', JSON.stringify({ lockScannerMode: true }));
     now = 0;
     global.performance = { now: () => now };
     input = {


### PR DESCRIPTION
## Summary
- allow manual typing by default with unlocked scanner
- refocus code input after RZ selection and item registration
- support Enter to consult and Ctrl+Enter to register, with tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a123d6769c832b9f67bc7db57477ab