### PR TITLE
refactor: centralize NCM cache key constant

### DIFF
--- a/src/config/runtime.js
+++ b/src/config/runtime.js
@@ -1,6 +1,8 @@
+export const NCM_CACHE_KEY = 'ncmCache:v1';
+
 export const RUNTIME = {
   NCM_API_BASE: import.meta.env.VITE_NCM_API_BASE || 'https://portalunico.siscomex.gov.br/classif/api/publico',
   NCM_API_TOKEN: import.meta.env.VITE_NCM_API_TOKEN || '',
   NCM_LOCAL_MAP_URL: '/data/ncm.json',
-  CACHE_KEY: 'confApp.ncm.cache.v1'
+  CACHE_KEY: NCM_CACHE_KEY
 };

--- a/src/services/ncmService.js
+++ b/src/services/ncmService.js
@@ -1,6 +1,6 @@
-import { RUNTIME } from '../config/runtime.js';
+import { RUNTIME, NCM_CACHE_KEY } from '../config/runtime.js';
 
-const CACHE_KEY = 'ncmCache:v1';
+const CACHE_KEY = NCM_CACHE_KEY;
 const mem = new Map();
 const prom = new Map();
 let mapPromise;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,3 +1,5 @@
+import { NCM_CACHE_KEY } from '../config/runtime.js';
+
 // src/store/index.js
 const state = {
   currentRZ: null,
@@ -33,7 +35,7 @@ const state = {
   // cache simples de NCM por SKU
   ncmCache: (() => {
     try {
-      return JSON.parse(localStorage.getItem('ncmCache:v1') || '{}');
+      return JSON.parse(localStorage.getItem(NCM_CACHE_KEY) || '{}');
     } catch {
       return {};
     }
@@ -101,7 +103,7 @@ export function setItens(items = []){
   state.conferidosByRZSku = {};
   state.excedentes = {};
   if(!state.currentRZ) state.currentRZ = Object.keys(itemsByRZ)[0] || null;
-  try{ localStorage.setItem('ncmCache:v1', JSON.stringify(state.ncmCache)); }catch{}
+  try{ localStorage.setItem(NCM_CACHE_KEY, JSON.stringify(state.ncmCache)); }catch{}
   return { itemsByRZ, totalByRZSku, metaByRZSku };
 }
 
@@ -324,7 +326,7 @@ export function setItemNcm(id, ncm, source){
     item.ncmMeta = { source, ts, status:'ok' };
   }
   state.ncmCache[sku] = ncm;
-  try{ localStorage.setItem('ncmCache:v1', JSON.stringify(state.ncmCache)); }catch{}
+  try{ localStorage.setItem(NCM_CACHE_KEY, JSON.stringify(state.ncmCache)); }catch{}
   if(typeof document !== 'undefined') document.dispatchEvent(new Event('ncm-update'));
 }
 

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import store, { totalPendentesCount, setItemNcm, setItemNcmStatus, selectAllItems } from '../src/store/index.js';
+import { NCM_CACHE_KEY } from '../src/config/runtime.js';
 
 describe('store state structure', () => {
   it('has basic keys', () => {
@@ -38,7 +39,7 @@ describe('NCM helpers', () => {
     setItemNcm(id, '12345678', 'api');
     expect(store.state.metaByRZSku['RZ1'].SKU1).toMatchObject({ ncm: '12345678', ncm_source: 'api', ncm_status: 'ok', ncmMeta: { source:'api', status:'ok' } });
     expect(store.state.itemsByRZ['RZ1'][0]).toMatchObject({ ncm: '12345678', ncmMeta: { source:'api', status:'ok' } });
-    const cache = JSON.parse(localStorage.getItem('ncmCache:v1'));
+      const cache = JSON.parse(localStorage.getItem(NCM_CACHE_KEY));
     expect(cache).toHaveProperty('SKU1', '12345678');
   });
 


### PR DESCRIPTION
## Summary
- export `NCM_CACHE_KEY` in runtime config and map `RUNTIME.CACHE_KEY` to it for compatibility
- replace literal `'ncmCache:v1'` usages in NCM service and store with the shared constant
- update tests to use the shared constant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a330cced64832bbb7dd62f4eb5c2d1