### PR TITLE
Handle import parsing errors with toast notification

### DIFF
--- a/src/components/ImportPanel.js
+++ b/src/components/ImportPanel.js
@@ -3,6 +3,7 @@ import { parsePlanilha } from '../utils/excel.js';
 import store, { setCurrentRZ, setRZs, setItens } from '../store/index.js';
 import { startNcmQueue } from '../services/ncmQueue.js';
 import { loadPrefs } from '../utils/prefs.js';
+import { toast } from '../utils/toast.js';
 
 export function initImportPanel(render){
   const fileInput = document.getElementById('file');
@@ -20,10 +21,23 @@ export function initImportPanel(render){
     }
     if (!f) return;
     const buf = (f.arrayBuffer ? await f.arrayBuffer() : f);
-    const { rzs, itens } = await parsePlanilha(buf);
+    let rzs = [];
+    let itens = [];
+    try {
+      ({ rzs, itens } = await parsePlanilha(buf));
+    } catch (err) {
+      console.error(err);
+      toast.error('Não foi possível processar a planilha...');
+      return;
+    }
     setRZs(rzs);
     setItens(itens);
-    if (ncmActive) startNcmQueue(itens);
+    try {
+      if (ncmActive) startNcmQueue(itens);
+    } catch (err) {
+      console.error(err);
+      toast.error('Não foi possível processar a planilha...');
+    }
     if (rzSelect){
       rzSelect.innerHTML = rzs.map(rz=>`<option value="${rz}">${rz}</option>`).join('');
       if (rzs.length){

--- a/tests/import-panel.spec.js
+++ b/tests/import-panel.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+vi.mock('../src/utils/excel.js', () => ({ parsePlanilha: vi.fn() }));
+vi.mock('../src/services/ncmQueue.js', () => ({ startNcmQueue: vi.fn() }));
+vi.mock('../src/utils/prefs.js', () => ({ loadPrefs: () => ({ ncmEnabled: false }) }));
+import { initImportPanel } from '../src/components/ImportPanel.js';
+import { parsePlanilha } from '../src/utils/excel.js';
+import store from '../src/store/index.js';
+import { toast } from '../src/utils/toast.js';
+
+describe('ImportPanel error handling', () => {
+  let fileEl;
+
+  beforeEach(() => {
+    store.state.rzList = [];
+    store.state.itemsByRZ = {};
+    store.state.currentRZ = null;
+
+    const elements = {};
+    function createEl(tag = 'input') {
+      return {
+        tagName: tag.toUpperCase(),
+        textContent: '',
+        title: '',
+        value: '',
+        classList: { add: () => {} },
+        addEventListener(type, fn) { (this._l ||= {})[type] = fn; },
+      };
+    }
+    elements['file'] = createEl('input');
+
+    global.document = {
+      body: { appendChild: () => {} },
+      createElement: () => ({ remove: () => {}, setAttribute: () => {}, className: '', textContent: '' }),
+      getElementById: (id) => elements[id] || null,
+      addEventListener: () => {},
+      querySelector: () => null,
+      querySelectorAll: () => [],
+    };
+
+    initImportPanel(() => {});
+    fileEl = elements['file'];
+  });
+
+  it('emits toast.error and keeps state when parse fails', async () => {
+    parsePlanilha.mockRejectedValue(new Error('fail'));
+    const spy = vi.spyOn(toast, 'error').mockImplementation(() => {});
+    const file = { name: 'x.xlsx', arrayBuffer: async () => new ArrayBuffer(0) };
+    await fileEl._l.change({ target: { files: [file] } });
+    expect(spy).toHaveBeenCalledWith('Não foi possível processar a planilha...');
+    expect(store.state.rzList).toEqual([]);
+    expect(store.state.itemsByRZ).toEqual({});
+    expect(store.state.currentRZ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- show toast and log when parsing or NCM queue fails
- test ImportPanel error handling for parse failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a33247c794832b99d134cd7914d8ff