### PR TITLE
feat: add NCM management page

### DIFF
--- a/ncm.html
+++ b/ncm.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Gerenciar NCM</title>
+  <link rel="stylesheet" href="/src/styles.css" />
+</head>
+<body>
+  <main class="container" style="padding:16px;max-width:600px">
+    <h1>Gerenciar NCM</h1>
+
+    <section class="card">
+      <div class="card-body">
+        <div class="field">
+          <label for="term" class="label">Termo</label>
+          <input id="term" class="input" placeholder="SKU ou descrição" />
+        </div>
+        <div class="field">
+          <label for="ncm" class="label">NCM</label>
+          <input id="ncm" class="input" placeholder="00000000" />
+        </div>
+        <div class="actions" style="margin-top:8px;display:flex;gap:8px">
+          <button id="btn-search" class="btn btn-primary" type="button">Buscar</button>
+          <button id="btn-save" class="btn" type="button">Salvar</button>
+        </div>
+        <div id="result" class="muted" style="margin-top:8px"></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-body" style="display:flex;flex-wrap:wrap;gap:8px">
+        <button id="btn-export" class="btn" type="button">Exportar cache</button>
+        <button id="btn-import" class="btn" type="button">Importar cache</button>
+        <input id="file-import" type="file" accept="application/json" hidden />
+        <button id="btn-clear" class="btn btn-warn" type="button">Limpar cache</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="card-body">
+        <label for="queue-items" class="label">Itens para fila (JSON)</label>
+        <textarea id="queue-items" class="input" rows="5" placeholder='[{"codigoRZ":"RZ1","codigoML":"SKU","descricao":"Desc"}]'></textarea>
+        <button id="btn-queue" class="btn btn-primary" type="button" style="margin-top:8px">Disparar fila</button>
+      </div>
+    </section>
+  </main>
+  <script type="module" src="/src/ncm.js"></script>
+</body>
+</html>

--- a/src/ncm.js
+++ b/src/ncm.js
@@ -1,0 +1,137 @@
+import { NCM_CACHE_KEY } from './config/runtime.js';
+import { resolve, normalizeNCM, slug, cacheSet } from './services/ncmService.js';
+import { startNcmQueue } from './services/ncmQueue.js';
+import store from './store/index.js';
+import toast from './utils/toast.js';
+
+function readCache() {
+  try {
+    return JSON.parse(localStorage.getItem(NCM_CACHE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(data) {
+  localStorage.setItem(NCM_CACHE_KEY, JSON.stringify(data));
+}
+
+const termEl = document.getElementById('term');
+const ncmEl = document.getElementById('ncm');
+const resultEl = document.getElementById('result');
+const queueEl = document.getElementById('queue-items');
+
+// Busca NCM no cache/API
+async function onSearch() {
+  const term = termEl.value.trim();
+  if (!term) return;
+  resultEl.textContent = 'Buscando…';
+  try {
+    const r = await resolve(term);
+    if (r?.ncm) {
+      ncmEl.value = r.ncm;
+      resultEl.textContent = `Fonte: ${r.source}`;
+    } else {
+      ncmEl.value = '';
+      resultEl.textContent = 'NCM não encontrado';
+    }
+  } catch (err) {
+    console.error(err);
+    resultEl.textContent = 'Erro na busca';
+    toast.error('Erro na busca');
+  }
+}
+
+// Salva NCM manualmente
+function onSave() {
+  const term = termEl.value.trim();
+  const ncm = normalizeNCM(ncmEl.value);
+  if (!term || !ncm) {
+    toast.warn('Informe termo e NCM válido');
+    return;
+  }
+  const key = slug(term);
+  cacheSet(key, { ncm, source: 'manual', ts: Date.now() });
+  toast.success('Salvo no cache');
+}
+
+// Exporta cache para JSON
+function onExport() {
+  const data = localStorage.getItem(NCM_CACHE_KEY) || '{}';
+  const blob = new Blob([data], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `${NCM_CACHE_KEY}.json`;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+// Importa cache JSON
+const fileInput = document.getElementById('file-import');
+function onImportFile() { fileInput.click(); }
+fileInput.addEventListener('change', () => {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result || '{}');
+      if (typeof data !== 'object' || Array.isArray(data)) throw new Error('Formato');
+      const cache = readCache();
+      Object.assign(cache, data);
+      writeCache(cache);
+      toast.success('Cache importado');
+    } catch {
+      toast.error('JSON inválido');
+    }
+  };
+  reader.readAsText(file);
+  fileInput.value = '';
+});
+
+// Limpa cache
+function onClear() {
+  if (confirm('Limpar todo cache NCM?')) {
+    writeCache({});
+    toast.info('Cache limpo');
+  }
+}
+
+// Dispara fila de NCM
+async function onQueue() {
+  let items;
+  try {
+    items = JSON.parse(queueEl.value || '[]');
+  } catch {
+    toast.error('JSON inválido');
+    return;
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    toast.warn('Nenhum item informado');
+    return;
+  }
+  for (const it of items) {
+    const rz = it.codigoRZ || 'RZ';
+    const sku = String(it.codigoML || '').trim().toUpperCase();
+    (store.state.itemsByRZ[rz] ||= []).push({ codigoML: sku, descricao: it.descricao });
+    (store.state.metaByRZSku[rz] ||= {});
+    store.state.metaByRZSku[rz][sku] = { descricao: it.descricao };
+  }
+  toast.info('Fila iniciada');
+  try {
+    await startNcmQueue(items);
+    toast.success('Fila concluída');
+  } catch (err) {
+    console.error(err);
+    toast.error('Erro na fila');
+  }
+}
+
+// Bind events
+document.getElementById('btn-search').addEventListener('click', onSearch);
+document.getElementById('btn-save').addEventListener('click', onSave);
+document.getElementById('btn-export').addEventListener('click', onExport);
+document.getElementById('btn-import').addEventListener('click', onImportFile);
+document.getElementById('btn-clear').addEventListener('click', onClear);
+document.getElementById('btn-queue').addEventListener('click', onQueue);
+


### PR DESCRIPTION
## Summary
- add dedicated `ncm.html` page for managing NCM cache
- implement client-side NCM tools (search, save, export/import, queue trigger)

## Testing
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a33a7f6e04832b80db099838b53dd0