### PR TITLE
feat: add NCM console page

### DIFF
--- a/public/ncm.html
+++ b/public/ncm.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Console de NCM</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      background: #fff;
+      color: #000;
+    }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    button, label {
+      cursor: pointer;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th, td {
+      border: 1px solid #333;
+      padding: 0.25rem 0.5rem;
+    }
+    th {
+      background: #000;
+      color: #fff;
+    }
+  </style>
+</head>
+<body>
+  <h1>Console de NCM</h1>
+  <div class="toolbar">
+    <input id="q" type="search" placeholder="Descrição, SKU ou termo..." aria-label="Descrição, SKU ou termo">
+    <button id="btnSearch">Buscar</button>
+    <select id="source" aria-label="Fonte de dados">
+      <option value="cache">cache</option>
+      <option value="api">api</option>
+    </select>
+    <button id="btnBulkQueue">Rodar fila de NCM</button>
+    <button id="btnExport">Exportar cache</button>
+    <label for="importFile" id="btnImport" role="button">+</label>
+    <input id="importFile" type="file" accept="application/json" hidden>
+    <button id="btnClear">Limpar cache</button>
+    <span id="endpointInfo" aria-live="polite"></span>
+  </div>
+  <table id="tbl">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Chave</th>
+        <th scope="col">Descrição</th>
+        <th scope="col">NCM</th>
+        <th scope="col">Origem</th>
+        <th scope="col">Ações</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script type="module" src="/src/pages/ncm/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add public NCM console page with search toolbar and results table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33c1ec8f8832b9dbd939f06be7cb3