### PR TITLE
Configure Vite multipage build with alias

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,27 @@
 import { defineConfig } from 'vite';
+import path from 'path';
 
 export default defineConfig({
   base: '/',
+  root: '.',
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        ncm: path.resolve(__dirname, 'public/ncm.html'),
+      },
+    },
+  },
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
   server: {
     proxy: {
       '/api/ncm': {
         target: 'https://portalunico.siscomex.gov.br',
         changeOrigin: true,
-        rewrite: p => p.replace(/^\/api\/ncm/, '/classif/api/publico/ncm')
-      }
-    }
-  }
+        rewrite: p => p.replace(/^\/api\/ncm/, '/classif/api/publico/ncm'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- configure build inputs for index.html and public/ncm.html
- add `@` alias pointing to `src`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a33e857d54832bbad636c2e9b590e2