### PR TITLE
fix: render KPIs without removing other home cards

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,78 +1,73 @@
-import store from '../store/index.js';
 import { loadPrefs, savePrefs } from '../utils/prefs.js';
-import { startNcmQueue } from '../services/ncmQueue.js';
 
 export function initDashboard() {
-  const pst = document.querySelector('[data-panel="home"]') || document.querySelector('.dashboard') || document.body;
-  if (!pst) return;
+  // Local onde os KPIs devem aparecer
+  let kpiHost = document.querySelector('.kpis');
 
-  const prefs = loadPrefs?.() || { ncmEnabled: true };
+  // Se ainda não existir o contêiner, criamos UM acima do card de importação,
+  // sem remover nada do DOM.
+  if (!kpiHost) {
+    const importCard = document.getElementById('card-importacao');
+    if (importCard) {
+      importCard.insertAdjacentHTML('beforebegin', '<div class="kpis"></div>');
+      kpiHost = importCard.previousElementSibling;
+    } else {
+      // fallback: adiciona no topo do main, mas sem limpar nada
+      const main = document.querySelector('main .container, main') || document.body;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'kpis';
+      main.prepend(wrapper);
+      kpiHost = wrapper;
+    }
+  }
 
-  pst.innerHTML = `
-    <div class="dashboard-header">
-      <h2 class="section-title">Conferência</h2>
-
-      <label class="switch">
-        <input type="checkbox" id="dash-ncm" ${prefs.ncmEnabled ? 'checked' : ''} />
-        <span>Resolver NCM</span>
-      </label>
-    </div>
-
-    <div class="kpis">
-      <div class="kpi" id="kpi-total">
-        <svg class="ico" aria-hidden="true" focusable="false">
-          <use href="/icons.svg#box"></use>
-        </svg>
-        <div>
-          <div class="kpi-label">Itens do lote</div>
-          <div class="kpi-value"><span id="kpi-total-val">0</span></div>
-        </div>
-      </div>
-
-      <div class="kpi" id="kpi-conf">
-        <svg class="ico" aria-hidden="true" focusable="false">
-          <use href="/icons.svg#check"></use>
-        </svg>
-        <div>
-          <div class="kpi-label">Conferidos</div>
-          <div class="kpi-value"><span id="kpi-conf-val">0</span></div>
-        </div>
-      </div>
-
-      <div class="kpi" id="kpi-exc">
-        <svg class="ico" aria-hidden="true" focusable="false">
-          <use href="/icons.svg#alert"></use>
-        </svg>
-        <div>
-          <div class="kpi-label">Excedentes</div>
-          <div class="kpi-value"><span id="kpi-exc-val">0</span></div>
-        </div>
-      </div>
-
-      <div class="kpi" id="kpi-pend">
-        <svg class="ico" aria-hidden="true" focusable="false">
-          <use href="/icons.svg#scan"></use>
-        </svg>
-        <div>
-          <div class="kpi-label">Pendentes</div>
-          <div class="kpi-value"><span id="kpi-pend-val">0</span></div>
-        </div>
+  // NÃO toque no resto da página. Apenas preencha o grid de KPIs.
+  const kpisHTML = `
+    <div class="kpi" id="kpi-total">
+      <svg class="ico" aria-hidden="true" focusable="false"><use href="/icons.svg#box"></use></svg>
+      <div>
+        <div class="kpi-label">Itens do lote</div>
+        <div class="kpi-value"><span id="kpi-total-val">0</span></div>
       </div>
     </div>
 
-    <div class="quick-actions">
-      <button id="dash-finalizar" class="btn btn-primary" type="button">Finalizar Conferência</button>
-      <button id="dash-export" class="btn btn-ghost" type="button">Exportar Excel</button>
+    <div class="kpi" id="kpi-conf">
+      <svg class="ico" aria-hidden="true" focusable="false"><use href="/icons.svg#check"></use></svg>
+      <div>
+        <div class="kpi-label">Conferidos</div>
+        <div class="kpi-value"><span id="kpi-conf-val">0</span></div>
+      </div>
+    </div>
+
+    <div class="kpi" id="kpi-exc">
+      <svg class="ico" aria-hidden="true" focusable="false"><use href="/icons.svg#alert"></use></svg>
+      <div>
+        <div class="kpi-label">Excedentes</div>
+        <div class="kpi-value"><span id="kpi-exc-val">0</span></div>
+      </div>
+    </div>
+
+    <div class="kpi" id="kpi-pend">
+      <svg class="ico" aria-hidden="true" focusable="false"><use href="/icons.svg#scan"></use></svg>
+      <div>
+        <div class="kpi-label">Pendentes</div>
+        <div class="kpi-value"><span id="kpi-pend-val">0</span></div>
+      </div>
     </div>
   `;
 
-  // (se já existirem handlers antigos, preserve-os fora desta função ou readicione aqui)
+  // Renderiza os KPIs apenas dentro do host
+  if (kpiHost) {
+    kpiHost.innerHTML = kpisHTML;
+  }
+
+  // Se existir o checkbox para habilitar NCM no cabeçalho, apenas ligue o handler.
   const chk = document.getElementById('dash-ncm');
-  if (chk) {
+  if (chk && typeof loadPrefs === 'function' && typeof savePrefs === 'function') {
     chk.addEventListener('change', (e) => {
-      const p = typeof loadPrefs === 'function' ? loadPrefs() : {};
+      const p = loadPrefs();
       p.ncmEnabled = !!e.target.checked;
-      if (typeof savePrefs === 'function') savePrefs(p);
+      savePrefs(p);
     });
   }
 }

--- a/src/components/NcmPanel.js
+++ b/src/components/NcmPanel.js
@@ -4,6 +4,7 @@ import { startNcmQueue } from '../services/ncmQueue.js';
 
 export function initNcmPanel(){
   const panel = document.getElementById('card-ncm');
+  if (!panel) return;
   const tbody = document.getElementById('ncm-table');
   const progress = document.getElementById('ncm-progress');
   const progressCount = document.getElementById('ncm-progress-count');


### PR DESCRIPTION
## Summary
- render KPIs in dedicated host without clearing other DOM elements
- guard NCM panel initialization when container is absent

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8cedb131c832bb506f3df17fbd5d6