### PR TITLE
Open Excedente dialog for unknown SKU

### DIFF
--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -21,14 +21,21 @@ function mostrarProdutoInfo(item) {
 function abrirModalExcedente(sku, fonte='manual'){
   const dlg = document.getElementById('dlg-excedente');
   if (!dlg) return;
-  document.getElementById('exc-sku').value = sku;
-  document.getElementById('exc-desc').value = '';
-  document.getElementById('exc-qtd').value = 1;
-  document.getElementById('exc-preco').value = '';
-  document.getElementById('exc-obs').value = '';
+  const inpSku   = document.getElementById('exc-sku');
+  const inpDesc  = document.getElementById('exc-desc');
+  const inpQtd   = document.getElementById('exc-qtd');
+  const inpPreco = document.getElementById('exc-preco');
+  const inpObs   = document.getElementById('exc-obs');
+
+  if (inpSku)   inpSku.value = sku;
+  if (inpDesc)  inpDesc.value = '';
+  if (inpQtd)   inpQtd.value = 1;
+  if (inpPreco) inpPreco.value = '';
+  if (inpObs)   inpObs.value = '';
+
   dlg.dataset.fonte = fonte;
-  dlg.showModal();
-  document.getElementById('exc-preco').focus();
+  dlg.showModal?.();
+  if (inpDesc) setTimeout(() => inpDesc.focus(), 0);
 }
 
 export function initActionsPanel(render){
@@ -128,7 +135,8 @@ export function initActionsPanel(render){
             return true;
           }
         }
-        toast.warn('Produto não encontrado; você pode registrar sem preço.');
+        toast('Este SKU não está no RZ atual. Você pode registrá-lo como Excedente.', 'warn');
+        abrirModalExcedente(sku, fonte);
         document.getElementById('produto-info').hidden = true;
         return false;
       }

--- a/tests/actions-open-excedente.spec.js
+++ b/tests/actions-open-excedente.spec.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initActionsPanel } from '../src/components/ActionsPanel.js';
+import store from '../src/store/index.js';
+
+function createEl(tag = 'input') {
+  const el = {
+    tagName: tag.toUpperCase(),
+    value: '',
+    classList: { add: () => {}, remove: () => {} },
+    focus() { document.activeElement = this; },
+    select() {},
+    addEventListener(type, fn) { (el._l ||= {})[type] = fn; },
+    click() { el._l?.click?.({}); },
+    dispatchEvent(ev) { el._l?.[ev.type]?.(ev); },
+    setAttribute: () => {},
+    removeAttribute: () => {},
+  };
+  return el;
+}
+
+describe('consultar opens excedente when SKU missing', () => {
+  let elements, input, btnCons, dlg, excSku;
+
+  beforeEach(() => {
+    elements = {};
+    elements['input-codigo-produto'] = createEl('input');
+    elements['btn-consultar'] = createEl('button');
+    elements['btn-registrar'] = createEl('button');
+    elements['obs-preset'] = createEl('select');
+    elements['preco-ajustado'] = createEl('input');
+    elements['pi-sku'] = { textContent: '' };
+    elements['pi-desc'] = { textContent: '' };
+    elements['pi-qtd'] = { textContent: '' };
+    elements['pi-preco'] = { textContent: '' };
+    elements['pi-total'] = { textContent: '' };
+    elements['pi-rz'] = { textContent: '' };
+    elements['pi-ncm'] = { textContent: '' };
+    elements['produto-info'] = { hidden: false };
+
+    dlg = { open: false, dataset: {}, showModal: vi.fn(function(){ this.open = true; }), close: () => {} };
+    elements['dlg-excedente'] = dlg;
+    excSku = createEl('input');
+    elements['exc-sku'] = excSku;
+    elements['exc-desc'] = createEl('input');
+    elements['exc-qtd'] = createEl('input');
+    elements['exc-preco'] = createEl('input');
+    elements['exc-obs'] = createEl('input');
+
+    global.document = {
+      body: { appendChild: () => {} },
+      activeElement: null,
+      getElementById: (id) => elements[id] || null,
+      querySelector: (sel) => elements[sel.replace('#', '')] || null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      createElement: () => ({ className: '', setAttribute: () => {}, textContent: '', remove: () => {} }),
+    };
+    global.window = { refreshIndicators: () => {}, scrollTo: () => {} };
+    global.localStorage = { _s:{}, getItem(k){return this._s[k]||null;}, setItem(k,v){this._s[k]=String(v);}, removeItem(k){delete this._s[k];}, clear(){this._s={};} };
+
+    store.state.rzAtual = 'R1';
+    store.state.totalByRZSku = {};
+    store.state.metaByRZSku = {};
+    store.state.conferidosByRZSku = {};
+    store.state.excedentes = {};
+
+    initActionsPanel(() => {});
+    input = elements['input-codigo-produto'];
+    btnCons = elements['btn-consultar'];
+  });
+
+  it('prefills SKU and shows modal when item not found', () => {
+    input.value = 'NAOEXISTE';
+    btnCons.click();
+    expect(excSku.value).toBe('NAOEXISTE');
+    expect(dlg.showModal).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Prefill and focus Excedente dialog when consulting a SKU not found in current RZ
- Trigger Excedente flow with warning toast when lookup fails
- Add test ensuring missing SKU opens Excedente dialog with SKU prefilled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8d1e3f79c832b973e5a936cdce4ab