### PR TITLE
feat: optional excedente price and NCM toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
       </h1>
       <div class="actions">
         <a href="/ncm.html" title="Console de NCM" class="btn btn-ghost">NCM</a>
+        <label class="switch" style="display:inline-flex;gap:8px;align-items:center">
+          <input type="checkbox" id="resolve-ncm" />
+          <span>Resolver NCM</span>
+        </label>
         <button id="helpBtn" title="Ajuda/Atalhos" aria-label="Ajuda" class="btn btn-ghost">?</button>
       </div>
     </header>
@@ -300,7 +304,7 @@
       </div>
       <div class="field">
         <label for="exc-preco">Preço unitário (R$)</label>
-        <input id="exc-preco" type="number" step="0.01" min="0.01" required class="input" />
+        <input id="exc-preco" type="number" step="0.01" min="0" class="input" />
       </div>
       <div class="field">
         <label for="exc-obs">Observação</label>

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -6,6 +6,7 @@ import { loadPrefs, savePrefs } from '../utils/prefs.js';
 import { toast } from '../utils/toast.js';
 import { openExcedenteModal } from './ExcedenteModal.js';
 import { updateBoot } from '../utils/boot.js';
+import { renderCounts } from '../utils/ui.js';
 
 // memória da última consulta
 let lastLookup = {
@@ -28,20 +29,6 @@ function findItemBySku(sku) {
     return all.find(x => String(x.sku).trim().toUpperCase() === String(sku).trim().toUpperCase()) || null;
   }
   return null;
-}
-
-function getCounts() {
-  const rz = store.state?.rzAtual;
-  const cont = store.state?.contadores?.[rz] || {};
-  return { total: cont.total || 0, conferidos: cont.conferidos || 0 };
-}
-
-function renderCounts() {
-  const { total, conferidos } = getCounts();
-  const kpi = document.getElementById('count-conferidos');
-  if (kpi) kpi.textContent = String(conferidos);
-  const hdr = document.getElementById('hdr-conferidos');
-  if (hdr) hdr.textContent = `${conferidos} de ${total} conferidos`;
 }
 
 function setNcmCheckedForSku(sku, checked) {
@@ -349,7 +336,7 @@ export function initActionsPanel(render){
         };
       });
       const excedentes = (store.state.excedentes[rz] || []).map(it => {
-        const p = it.preco === undefined || it.preco === null ? null : Number(it.preco);
+        const p = it.preco_unit === undefined || it.preco_unit === null ? null : Number(it.preco_unit);
         return {
           SKU: it.sku,
           Descrição: it.descricao || '',
@@ -379,28 +366,12 @@ export function initActionsPanel(render){
     }
   });
 
-  document.getElementById('exc-salvar')?.addEventListener('click', ()=>{
-    const dlg = document.getElementById('dlg-excedente');
-    const sku = document.getElementById('exc-sku').value.trim().toUpperCase();
-    const desc = document.getElementById('exc-desc').value.trim();
-    const qtd  = Number(document.getElementById('exc-qtd').value) || 1;
-    const precoStr = document.getElementById('exc-preco').value;
-    const preco = precoStr.trim() === '' ? undefined : Number(precoStr);
-    const obs  = document.getElementById('exc-obs').value.trim();
-    if (!sku || !desc) return;
-    addExcedente(store.state.rzAtual, { sku, descricao: desc, qtd, preco, obs, fonte: dlg?.dataset.fonte||'manual' });
-    dlg.close();
-    toast('Excedente salvo', 'info');
-    render();
-    window.refreshIndicators?.();
-  });
-
   document.addEventListener('keydown',(e)=>{
     if (e.ctrlKey && e.key.toLowerCase()==='k'){ e.preventDefault(); document.querySelector('#input-codigo-produto')?.focus(); }
     // Ctrl+Enter handled on codigoInput for registro
     if (e.ctrlKey && e.key.toLowerCase()==='s'){
       const dlg = document.getElementById('dlg-excedente');
-      if (dlg?.open) { e.preventDefault(); document.getElementById('exc-salvar')?.click(); }
+      if (dlg?.open) { e.preventDefault(); document.getElementById('form-exc')?.requestSubmit(); }
     }
     if (e.key==='Escape') document.getElementById('dlg-excedente')?.close();
   });

--- a/src/components/ImportPanel.js
+++ b/src/components/ImportPanel.js
@@ -2,15 +2,15 @@
 import { parsePlanilha } from '../utils/excel.js';
 import store, { setCurrentRZ, setRZs, setItens } from '../store/index.js';
 import { startNcmQueue } from '../services/ncmQueue.js';
-import { loadPrefs } from '../utils/prefs.js';
 import { toast } from '../utils/toast.js';
+import { loadSettings, renderCounts, renderExcedentes } from '../utils/ui.js';
 
 export function initImportPanel(render){
   const fileInput = document.getElementById('file');
   const fileName  = document.getElementById('file-name');
   const rzSelect  = document.getElementById('select-rz');
 
-  let ncmActive = loadPrefs().ncmEnabled;
+  let ncmActive = !!loadSettings().resolveNcm;
 
   fileInput?.addEventListener('change', async (e)=>{
     const f = e.target?.files?.[0];
@@ -32,6 +32,8 @@ export function initImportPanel(render){
     }
     setRZs(rzs);
     setItens(itens);
+    renderExcedentes();
+    renderCounts();
     try {
       if (ncmActive) startNcmQueue(itens);
     } catch (err) {

--- a/src/components/ResultsPanel.js
+++ b/src/components/ResultsPanel.js
@@ -28,7 +28,7 @@ function rowsPendentes(rz){
 function rowsExcedentes(rz){
   const list = store.state.excedentes[rz] || [];
   return list.map(it=>{
-    const preco = it.preco === undefined || it.preco === null ? null : Number(it.preco);
+    const preco = it.preco_unit === undefined || it.preco_unit === null ? null : Number(it.preco_unit);
     return {
       sku: it.sku,
       descricao: it.descricao||'',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,7 +25,7 @@ const state = {
   movimentos: [],         // [{ ts, rz, sku, precoAjustado, observacao }]
 
   // excedentes por RZ
-  excedentes: {},         // { [rz]: [ { sku, descricao, qtd, preco, obs, fonte, ncm } ] }
+  excedentes: {},         // { [rz]: [ { sku, descricao, qtd, preco_unit, obs, fonte, ncm } ] }
 
   limits: {
     conferidos: 50,
@@ -197,21 +197,21 @@ export function findEmOutrosRZ(sku){
   return null;
 }
 
-export function addExcedente(rz, { sku, descricao, qtd, preco, obs, fonte, ncm }){
+export function addExcedente(rz, { sku, descricao, qtd, preco_unit, obs, fonte, ncm }){
   const list = (state.excedentes[rz] ||= []);
   const existente = list.find(it => it.sku === sku);
   const q = Number(qtd) || 0;
-  const p = (preco === undefined || preco === null || preco === '') ? undefined : Number(preco);
+  const p = (preco_unit === undefined || preco_unit === null || preco_unit === '') ? undefined : Number(preco_unit);
   const metaNcm = ncm ?? state.metaByRZSku[rz]?.[sku]?.ncm ?? null;
   if (existente) {
     existente.qtd += q;
-    if (p !== undefined) existente.preco = p;
+    if (p !== undefined) existente.preco_unit = p;
     existente.obs = obs || existente.obs;
     existente.ncm = metaNcm ?? existente.ncm ?? null;
   } else {
-    list.push({ sku, descricao: descricao || '', qtd: q, preco: p, obs: obs || '', fonte: fonte || '', ncm: metaNcm });
+    list.push({ sku, descricao: descricao || '', qtd: q, preco_unit: p, obs: obs || '', fonte: fonte || '', ncm: metaNcm });
   }
-  state.movimentos.push({ ts: Date.now(), tipo: 'EXCEDENTE', rz, sku, qtd: q, preco: p, obs, fonte });
+  state.movimentos.push({ ts: Date.now(), tipo: 'EXCEDENTE', rz, sku, qtd: q, preco_unit: p, obs, fonte });
   updateContadores(rz);
 }
 
@@ -247,7 +247,7 @@ export function conferir(sku, opts = {}) {
 
 export function registrarExcedente({ sku, qty, price, note }) {
   const rz = state.rzAtual;
-  addExcedente(rz, { sku, descricao: '', qtd: qty, preco: price, obs: note, fonte: 'preset' });
+  addExcedente(rz, { sku, descricao: '', qtd: qty, preco_unit: price, obs: note, fonte: 'preset' });
 }
 
 function parseId(id){

--- a/src/styles.css
+++ b/src/styles.css
@@ -71,8 +71,9 @@ th.sticky{left:0;z-index:2}
   .actions-grid .row{grid-template-columns:1fr auto auto}
 }
 
-/* Kill-switch para garantir que o painel NCM não apareça na home */
-#card-ncm,[data-panel="ncm"]{display:none !important}
+/* Kill-switch para garantir que o painel NCM possa ser ocultado */
+.ncm-disabled #card-ncm,
+.ncm-disabled [data-panel="ncm"]{display:none !important}
 
 /* === KPI icons sizing & layout ========================================== */
 .kpis {

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,0 +1,138 @@
+import store from '../store/index.js';
+
+const SETTINGS_KEY = 'confApp.settings';
+
+export function loadSettings() {
+  try {
+    return JSON.parse(localStorage.getItem(SETTINGS_KEY)) || {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveSettings(s) {
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(s || {}));
+}
+
+export function applyNcmToggleToUI(enabled) {
+  const card = document.getElementById('card-ncm');
+  if (card) card.classList.toggle('collapsed', !enabled);
+  document.body?.classList.toggle('ncm-disabled', !enabled);
+}
+
+export function wireNcmToggle() {
+  const chkPrimary = document.getElementById('resolve-ncm');
+  const chkAlt = document.getElementById('dash-ncm');
+  const s = loadSettings();
+  const cur = !!s.resolveNcm;
+  if (chkPrimary) chkPrimary.checked = cur;
+  if (chkAlt) chkAlt.checked = cur;
+  applyNcmToggleToUI(cur);
+
+  const onChange = (v) => {
+    const s2 = loadSettings();
+    s2.resolveNcm = !!v;
+    saveSettings(s2);
+    applyNcmToggleToUI(!!v);
+    document.dispatchEvent(new CustomEvent('ncm-pref-changed', { detail: { enabled: !!v } }));
+  };
+
+  chkPrimary?.addEventListener('change', () => onChange(chkPrimary.checked));
+  chkAlt?.addEventListener('change', () => onChange(chkAlt.checked));
+}
+
+export function getExcedentes() {
+  if (typeof store?.state?.rzAtual !== 'undefined') {
+    return store.state.excedentes?.[store.state.rzAtual] || [];
+  }
+  const KEY = 'confApp.excedentes';
+  try { return JSON.parse(localStorage.getItem(KEY)) || []; } catch { return []; }
+}
+
+export function renderExcedentes() {
+  const tbody = document.getElementById('excedentesTable');
+  if (!tbody) return;
+  const data = getExcedentes();
+
+  tbody.innerHTML = '';
+  data.forEach(ex => {
+    const tr = document.createElement('tr');
+
+    const tdSku = document.createElement('td');
+    tdSku.textContent = ex.sku || '—';
+
+    const tdDesc = document.createElement('td');
+    tdDesc.textContent = ex.descricao || '—';
+
+    const tdQtd = document.createElement('td');
+    tdQtd.className = 'num';
+    tdQtd.textContent = String(ex.qtd ?? 0);
+
+    const tdPreco = document.createElement('td');
+    tdPreco.className = 'num';
+    tdPreco.textContent = ex.preco_unit == null ? '—' :
+      Number(ex.preco_unit).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+
+    const tdTotal = document.createElement('td');
+    tdTotal.className = 'num';
+    const tot = ex.preco_unit == null ? null : Number(ex.preco_unit) * Number(ex.qtd || 0);
+    tdTotal.textContent = tot == null ? '—' :
+      Number(tot).toLocaleString('pt-BR', { minimumFractionDigits: 2 });
+
+    const tdStatus = document.createElement('td');
+    tdStatus.textContent = ex.status || 'Excedente';
+
+    tr.appendChild(tdSku);
+    tr.appendChild(tdDesc);
+    tr.appendChild(tdQtd);
+    tr.appendChild(tdPreco);
+    tr.appendChild(tdTotal);
+    tr.appendChild(tdStatus);
+    tbody.appendChild(tr);
+  });
+}
+
+export function getAllItems() {
+  if (typeof store?.selectAllImportedItems === 'function') return store.selectAllImportedItems() || [];
+  return [];
+}
+
+export function getConfirmedItems() {
+  const items = [];
+  for (const [, map] of Object.entries(store.state.conferidosByRZSku || {})) {
+    for (const sku of Object.keys(map || {})) {
+      items.push({ sku });
+    }
+  }
+  return items;
+}
+
+export function getPendentesItems() {
+  const all = getAllItems();
+  const conf = new Set(getConfirmedItems().map(x => x.sku));
+  const exc = new Set(getExcedentes().map(x => x.sku));
+  return all.filter(x => !conf.has(x.sku) && !exc.has(x.sku));
+}
+
+function setText(el, value) { if (el) el.textContent = String(value); }
+
+export function renderCounts() {
+  const total = getAllItems().length;
+  const conferidos = getConfirmedItems().length;
+  const excedentes = getExcedentes().length;
+  const pend = getPendentesItems().length;
+
+  const kpiItens = document.querySelector('#card-importacao')?.closest('main')?.querySelector?.('.kpi-itens') || document.getElementById('count-itens');
+  setText(kpiItens, total);
+
+  setText(document.getElementById('count-conferidos'), conferidos);
+
+  const kpiExc = document.getElementById('excedentesCount') || document.getElementById('count-excedentes');
+  setText(kpiExc, excedentes);
+
+  const kpiPend = document.getElementById('count-pendentes') || document.getElementById('count-pend');
+  setText(kpiPend, pend);
+
+  const hdr = document.getElementById('hdr-conferidos');
+  if (hdr) hdr.textContent = `${conferidos} de ${total} conferidos`;
+}

--- a/tests/actions-enter-flow.spec.js
+++ b/tests/actions-enter-flow.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), loadSettings: () => ({}), renderExcedentes: () => {} }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 

--- a/tests/actions-excedente.spec.js
+++ b/tests/actions-excedente.spec.js
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), loadSettings: () => ({}), renderExcedentes: () => {} }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 
@@ -54,7 +55,7 @@ describe('actions excedente', () => {
     preco.value = '';
     btnReg.click();
     const exc = store.state.excedentes['R1'][0];
-    expect(exc.preco).toBeUndefined();
+    expect(exc.preco_unit).toBeUndefined();
     expect(obsSelect.value).toBe('');
     expect(preco.value).toBe('');
     expect(document.activeElement).toBe(input);
@@ -66,6 +67,6 @@ describe('actions excedente', () => {
     preco.value = '10';
     btnReg.click();
     const exc = store.state.excedentes['R1'][0];
-    expect(exc.preco).toBe(10);
+    expect(exc.preco_unit).toBe(10);
   });
 });

--- a/tests/actions-flow.spec.js
+++ b/tests/actions-flow.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), loadSettings: () => ({}), renderExcedentes: () => {} }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 
@@ -78,7 +79,7 @@ describe('actions flow', () => {
     btnReg.click();
     const exc = store.state.excedentes['R1'][0];
     expect(exc.sku).toBe('ZZZ');
-    expect(exc.preco).toBeUndefined();
+    expect(exc.preco_unit).toBeUndefined();
   });
 
   it('excedente registers without price', () => {
@@ -87,7 +88,7 @@ describe('actions flow', () => {
     preco.value = '';
     btnReg.click();
     const exc = store.state.excedentes['R1'][0];
-    expect(exc.preco).toBeUndefined();
+    expect(exc.preco_unit).toBeUndefined();
   });
 
   it('Enter consults and Ctrl+Enter registers', () => {

--- a/tests/actions-focus.spec.js
+++ b/tests/actions-focus.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), renderExcedentes: vi.fn(), loadSettings: () => ({ resolveNcm: false }) }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import { initImportPanel } from '../src/components/ImportPanel.js';
 import store from '../src/store/index.js';

--- a/tests/actions-open-excedente.spec.js
+++ b/tests/actions-open-excedente.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), loadSettings: () => ({}), renderExcedentes: () => {} }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 

--- a/tests/actions-panel.spec.js
+++ b/tests/actions-panel.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/ui.js', () => ({ renderCounts: vi.fn(), loadSettings: () => ({}), renderExcedentes: () => {} }));
 import { initActionsPanel } from '../src/components/ActionsPanel.js';
 import store from '../src/store/index.js';
 
@@ -59,7 +60,7 @@ describe('ActionsPanel behaviors', () => {
     btnReg.click();
     const exc = store.state.excedentes['R1'][0];
     expect(exc.sku).toBe('ABC');
-    expect(exc.preco).toBeUndefined();
+    expect(exc.preco_unit).toBeUndefined();
   });
 
   it('focus returns to input after register', () => {

--- a/tests/import-panel.spec.js
+++ b/tests/import-panel.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, expect, vi } from 'vitest';
 vi.mock('../src/utils/excel.js', () => ({ parsePlanilha: vi.fn() }));
 vi.mock('../src/services/ncmQueue.js', () => ({ startNcmQueue: vi.fn() }));
-vi.mock('../src/utils/prefs.js', () => ({ loadPrefs: () => ({ ncmEnabled: false }) }));
+vi.mock('../src/utils/ui.js', () => ({ loadSettings: () => ({ resolveNcm: false }), renderCounts: vi.fn(), renderExcedentes: vi.fn() }));
 import { initImportPanel } from '../src/components/ImportPanel.js';
 import { parsePlanilha } from '../src/utils/excel.js';
 import store from '../src/store/index.js';

--- a/tests/results-panel.spec.js
+++ b/tests/results-panel.spec.js
@@ -34,7 +34,7 @@ describe('renderResults row classes', () => {
     store.state.totalByRZSku = { R1: { A:1, B:1 } };
     store.state.conferidosByRZSku = { R1: { A: { qtd:1 } } };
     store.state.metaByRZSku = { R1: { A:{ descricao:'A', precoMedio:0 }, B:{ descricao:'B', precoMedio:0 } } };
-    store.state.excedentes = { R1: [ { sku:'E1', descricao:'Ex', qtd:1, preco:0 } ] };
+    store.state.excedentes = { R1: [ { sku:'E1', descricao:'Ex', qtd:1, preco_unit:0 } ] };
     store.state.contadores = { R1: { conferidos:1, total:2, excedentes:1 } };
   });
 


### PR DESCRIPTION
## Summary
- allow registering excedentes without unit price and show description in list
- add Resolve NCM toggle stored in settings and hide NCM panel when disabled
- recalculate KPIs after imports and registrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8db349e6c832b89c08d30146825ee