### PR TITLE
Use safe storage with fallback for conferência data

### DIFF
--- a/src/components/ExcedenteDialog.js
+++ b/src/components/ExcedenteDialog.js
@@ -1,0 +1,68 @@
+import { saveExcedente } from '../services/persist.js';
+import { updateBoot } from '../utils/boot.js';
+
+export function wireExcedenteDialog() {
+  const dlg  = document.getElementById('dlg-excedente');
+  const form = document.getElementById('form-exc');
+  const inputs = [
+    document.getElementById('exc-desc'),
+    document.getElementById('exc-qtd'),
+    document.getElementById('exc-preco'),
+    document.getElementById('exc-obs'),
+  ].filter(Boolean);
+
+  // Navegação com Enter entre campos; no último, Enter envia
+  inputs.forEach((el, idx) => {
+    el.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter') return;
+      e.preventDefault();
+      const last = idx === inputs.length - 1;
+      if (!last) {
+        inputs[idx + 1].focus();
+        inputs[idx + 1].select?.();
+      } else {
+        // submit programático
+        form.requestSubmit ? form.requestSubmit() : form.dispatchEvent(new Event('submit', {cancelable:true}));
+      }
+    });
+  });
+
+  // Envio do form → valida + salva + fecha + feedback
+  form?.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const sku   = document.getElementById('exc-sku')?.value?.trim();
+    const desc  = document.getElementById('exc-desc')?.value?.trim();
+    const qtd   = Number(document.getElementById('exc-qtd')?.value || 0);
+    const preco = document.getElementById('exc-preco')?.value; // opcional
+    const obs   = document.getElementById('exc-obs')?.value?.trim();
+
+    if (!sku)  { updateBoot('SKU inválido'); return; }
+    if (!desc) { updateBoot('Informe a descrição'); inputs[0]?.focus(); return; }
+    if (!(qtd >= 1)) { updateBoot('Qtd deve ser ≥ 1'); inputs[1]?.focus(); return; }
+
+    const reg = { sku, descricao: desc, qtd, preco_unit: (preco === '' ? null : Number(preco)), obs };
+    saveExcedente(reg);
+
+    try { dlg.close(); } catch {}
+    updateBoot(`Excedente salvo: ${sku} • ${desc}`);
+
+    // atualiza a lista/contadores imediatamente (ajuste para seus renders)
+    if (typeof window.refreshExcedentesTable === 'function') window.refreshExcedentesTable();
+    if (typeof window.refreshKpis === 'function') window.refreshKpis();
+  });
+
+  // Quando o diálogo abrir, focar descrição
+  dlg?.addEventListener('close', () => {
+    // nada; o submit já chama updateBoot
+  });
+  dlg?.addEventListener('show', () => {
+    inputs[0]?.focus();
+    inputs[0]?.select?.();
+  });
+}
+
+// chame isso no bootstrap da página:
+window.addEventListener('DOMContentLoaded', () => {
+  try { wireExcedenteDialog(); } catch {}
+});
+

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,8 @@ import './styles.css';
 import { initApp } from './components/app.js';
 import { initIndicators } from './components/Indicators.js';
 import { initScannerUI } from './components/ScannerUI.js';
+import './components/ExcedenteDialog.js';
+import './utils/kpis.js';
 
 if (import.meta.env?.DEV) {
   window.__DEBUG_SCAN__ = true;

--- a/src/services/persist.js
+++ b/src/services/persist.js
@@ -1,0 +1,22 @@
+import { getJSON, setJSON, updateArray } from '../utils/safeStorage.js';
+
+// Conferidos
+export function saveConferido(item) {
+  updateArray('confApp.conferidos', arr => {
+    arr.push(item);
+    return arr;
+  });
+}
+
+// Excedentes (SKU, descricao, qtd, preco_unit?, obs?)
+export function saveExcedente(reg) {
+  updateArray('confApp.excedentes', arr => {
+    arr.push(reg);
+    return arr;
+  });
+}
+
+// Leitura
+export function loadConferidos()  { return getJSON('confApp.conferidos',  []); }
+export function loadExcedentes()  { return getJSON('confApp.excedentes',  []); }
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -140,6 +140,13 @@ th.sticky{left:0;z-index:2}
   padding-top: 8px;
 }
 
+#boot-status{
+  position:fixed;left:16px;bottom:16px;z-index:1000;
+  background:#0B1221;color:#fff;border-radius:12px;
+  padding:10px 14px;box-shadow:0 10px 25px rgba(0,0,0,.2);
+}
+#boot-status strong{ margin-right:6px; color:#A7B3FF; }
+
 /* Responsivo */
 @media (max-width: 920px){
   .kpis{grid-template-columns:1fr 1fr}

--- a/src/utils/kpis.js
+++ b/src/utils/kpis.js
@@ -1,0 +1,18 @@
+import { loadConferidos, loadExcedentes } from '../services/persist.js';
+import store from '../store/index.js';
+
+export function refreshKpis() {
+  try {
+    const conferidos = (loadConferidos() || []).length;
+    const excedentes = (loadExcedentes() || []).length;
+    const total      = (typeof store?.selectAllImportedItems === 'function')
+      ? (store.selectAllImportedItems() || []).length : 0;
+    const pendentes  = Math.max(total - conferidos - excedentes, 0);
+
+    document.getElementById('count-conferidos')?.replaceChildren(document.createTextNode(String(conferidos)));
+    document.getElementById('excedentesCount')?.replaceChildren(document.createTextNode(String(excedentes)));
+    document.getElementById('count-pendentes') ?.replaceChildren(document.createTextNode(String(pendentes)));
+  } catch (e) { console.warn('refreshKpis', e); }
+}
+window.refreshKpis = refreshKpis;
+

--- a/src/utils/safeStorage.js
+++ b/src/utils/safeStorage.js
@@ -1,0 +1,38 @@
+// src/utils/safeStorage.js
+const mem = new Map();
+
+function warnOnce(msg) {
+  if (!warnOnce._set) warnOnce._set = new Set();
+  if (!warnOnce._set.has(msg)) { console.warn(msg); warnOnce._set.add(msg); }
+}
+
+export function getJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return mem.has(key) ? mem.get(key) : fallback;
+    return JSON.parse(raw);
+  } catch (e) {
+    warnOnce('[safeStorage] getJSON falhou, usando memória.');
+    return mem.has(key) ? mem.get(key) : fallback;
+  }
+}
+
+export function setJSON(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    mem.delete(key); // preferimos o LS quando deu certo
+    return true;
+  } catch (e) {
+    warnOnce('[safeStorage] setJSON: quota/erro → usando memória.');
+    mem.set(key, value);
+    return false;
+  }
+}
+
+export function updateArray(key, updater) {
+  const curr = getJSON(key, []);
+  const next = updater(Array.isArray(curr) ? curr.slice() : []);
+  setJSON(key, next);
+  return next;
+}
+

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,12 +1,7 @@
 import store from '../store/index.js';
+import { loadExcedentes, saveExcedente } from '../services/persist.js';
 
 const SETTINGS_KEY = 'confApp.settings';
-const EXC_KEY = 'confApp.excedentes';
-
-function loadJSON(key, fallback = []) {
-  try { return JSON.parse(localStorage.getItem(key)) ?? fallback; } catch { return fallback; }
-}
-function saveJSON(key, val) { localStorage.setItem(key, JSON.stringify(val)); }
 
 export function loadSettings() {
   try {
@@ -52,14 +47,12 @@ export function getExcedentes() {
   if (typeof store?.state?.rzAtual !== 'undefined') {
     return store.state.excedentes?.[store.state.rzAtual] || [];
   }
-  return loadJSON(EXC_KEY, []);
+  return loadExcedentes();
 }
 
 export function addExcedente(ex) {
   if (typeof store?.addExcedente === 'function') return store.addExcedente(store.state.rzAtual, ex);
-  const arr = getExcedentes();
-  arr.push(ex);
-  saveJSON(EXC_KEY, arr);
+  saveExcedente(ex);
 }
 
 export function renderExcedentes() {
@@ -105,31 +98,6 @@ export function renderExcedentes() {
   });
 }
 
-export function wireExcedenteDialog() {
-  const dlg = document.getElementById('dlg-excedente');
-  if (!dlg) return;
-
-  dlg.addEventListener('close', () => {
-    if (dlg.returnValue !== 'default') return;
-
-    const sku  = (document.getElementById('exc-sku')?.value || '').trim();
-    const desc = (document.getElementById('exc-desc')?.value || '').trim();
-    const qtd  = Math.max(1, Number(document.getElementById('exc-qtd')?.value || 1));
-
-    const precoIn = document.getElementById('exc-preco')?.value ?? '';
-    const preco = (precoIn === '' ? null : Math.max(0, Number(precoIn)));
-
-    const obs  = (document.getElementById('exc-obs')?.value || '').trim() || null;
-
-    if (!sku || !desc) return;
-
-    addExcedente({ sku, descricao: desc, qtd, preco_unit: preco, obs, status: 'excedente' });
-    renderExcedentes();
-    renderCounts();
-
-    window.dispatchEvent?.(new CustomEvent('app:changed', { detail: { type: 'excedente:add', sku } }));
-  });
-}
 
 export function getAllItems() {
   if (typeof store?.selectAllImportedItems === 'function') return store.selectAllImportedItems() || [];


### PR DESCRIPTION
## Summary
- add safeStorage helper with memory fallback to avoid localStorage quota issues
- persist conferidos and excedentes through new service and refresh KPIs on save
- improve excedente dialog with enter navigation and instant feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8f1b74708832b9e9ad5f4cca27ab5