### PR TITLE
feat: add Dexie lazy loader

### DIFF
--- a/src/services/db/indexedDb.js
+++ b/src/services/db/indexedDb.js
@@ -1,0 +1,17 @@
+let Dexie; // cache local
+
+export async function ensureDexie() {
+  if (Dexie) return Dexie;
+  const mod = await import('dexie');
+  Dexie = mod.default ?? mod;
+  return Dexie;
+}
+
+export async function openDb() {
+  const DX = await ensureDexie();
+  const db = new DX('conf-db');
+  db.version(1).stores({
+    items: '&sku, descricao, qtd, preco'
+  });
+  return db;
+}


### PR DESCRIPTION
## Summary
- add lazy loader helper for Dexie and database opening helper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9604582ec832b808f5c2680e0c760