### PR TITLE
feat: version badge and data reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
         </label>
         <button id="helpBtn" title="Ajuda/Atalhos" aria-label="Ajuda" class="btn btn-ghost">?</button>
         <button id="btn-download-backup" class="btn btn-ghost">Baixar backup</button>
+        <button id="btn-reset-db" class="btn btn-ghost">Resetar banco</button>
+        <span id="app-version" class="badge version-badge"></span>
       </div>
     </header>
 
@@ -292,7 +294,8 @@
   </main>
 
   <div id="boot-status" aria-live="polite">
-    <strong>Boot:</strong> aguardando…
+    <strong>Boot:</strong> <span class="boot-text">aguardando…</span>
+    <a id="boot-debug" class="debug-link" hidden>Debug</a>
   </div>
 
   <dialog id="dlg-excedente">

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,9 @@ import './styles.css';
 import { initImportPanel } from './components/ImportPanel.js';
 import { updateBoot } from './utils/boot.js';
 import { exportarPlanilha } from './services/exportExcel.js';
-import { resetDb } from './store/db.js';
+import { downloadSnapshot } from './services/backup.js';
+import { resetAllData } from './services/resetDb.js';
+import { db, resetDb } from './store/db.js';
 
 // utilitário opcional no console
 window.__resetDb = resetDb;
@@ -11,11 +13,22 @@ window.addEventListener('DOMContentLoaded', () => {
   initImportPanel();
   updateBoot('Boot: aplicativo carregado. Selecione a planilha e o RZ para iniciar.');
 
+  const verEl = document.getElementById('app-version');
+  if (verEl) verEl.textContent = `v${__APP_VERSION__ || 'dev'} • ${(__COMMIT_HASH__ || 'local').slice(0,7)}`;
+
   document.getElementById('finalizarBtn')?.addEventListener('click', () => {
     exportarPlanilha();
   });
   document.getElementById('btn-exportar')?.addEventListener('click', () => {
     exportarPlanilha();
+  });
+  document.getElementById('btn-download-backup')?.addEventListener('click', () => {
+    downloadSnapshot(db);
+  });
+  document.getElementById('btn-reset-db')?.addEventListener('click', async () => {
+    await resetAllData();
+    updateBoot('Banco zerado.');
+    location.reload();
   });
 });
 

--- a/src/services/exportExcel.js
+++ b/src/services/exportExcel.js
@@ -10,62 +10,57 @@ export async function exportarPlanilha() {
   const lote = await getMeta('loteAtual', '—');
   const agora = new Date().toLocaleString('pt-BR');
 
-  // cole seus dados das stores locais
   const conferidos = await db.itens.where('status').equals('Conferido').toArray();
-  const pendentes  = await db.itens.where('status').equals('Pendente').toArray();
+  const pendentes = await db.itens.where('status').equals('Pendente').toArray();
   const excedentes = await db.excedentes.toArray();
 
   const book = XLSX.utils.book_new();
 
-  // helpers
+  // Aba Resumo
+  const resumoLinhas = [
+    ['Lote', lote],
+    ['RZ', rz],
+    ['Data/Hora', agora]
+  ];
+  XLSX.utils.book_append_sheet(book, XLSX.utils.aoa_to_sheet(resumoLinhas), 'Resumo');
+
   const headerStyle = {
-    fill: { patternType: 'solid', fgColor: { rgb: 'FFA500' } }, // laranja
-    font: { bold: true, color: { rgb: '000000' } },
+    fill: { patternType: 'solid', fgColor: { rgb: 'F59E0B' } },
+    font: { bold: true, color: { rgb: 'FFFFFF' } },
     alignment: { vertical: 'center' }
   };
   const makeSheet = (linhas) => {
     const ws = XLSX.utils.aoa_to_sheet(linhas);
-    // aplica estilo na primeira linha
     const range = XLSX.utils.decode_range(ws['!ref'] || 'A1:A1');
     for (let c = range.s.c; c <= range.e.c; c++) {
-      const addr = XLSX.utils.encode_cell({ r: 3, c }); // linha 4 (0-based) = cabeçalho
+      const addr = XLSX.utils.encode_cell({ r: 0, c });
       if (!ws[addr]) continue;
       ws[addr].s = headerStyle;
     }
-    ws['!rows'] = [{ hpt: 14 }, { hpt: 14 }, { hpt: 8 }, { hpt: 18 }]; // altura meta + header
     return ws;
   };
 
-  // 5.1) Conferidos
+  // Conferidos
   {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço Méd','Valor Total','Status']
-    ];
+    const linhas = [['SKU','Descrição','Qtd','Preço Méd (R$)','Valor Total (R$)','Status']];
     for (const it of conferidos) {
       linhas.push([it.sku, it.descricao, it.qtd, it.precoMedio, it.valorTotal, 'Conferido']);
     }
     XLSX.utils.book_append_sheet(book, makeSheet(linhas), 'Conferidos');
   }
 
-  // 5.2) Pendentes
+  // Pendentes
   {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço Méd','Valor Total','Status']
-    ];
+    const linhas = [['SKU','Descrição','Qtd','Preço Méd (R$)','Valor Total (R$)','Status']];
     for (const it of pendentes) {
       linhas.push([it.sku, it.descricao, it.qtd, it.precoMedio, it.valorTotal, 'Pendente']);
     }
     XLSX.utils.book_append_sheet(book, makeSheet(linhas), 'Pendentes');
   }
 
-  // 5.3) Excedentes
+  // Excedentes
   {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço (R$)','Valor Total (R$)','Status']
-    ];
+    const linhas = [['SKU','Descrição','Qtd','Preço (R$)','Valor Total (R$)','Status']];
     for (const ex of excedentes) {
       const total = Number(ex.qtd || 0) * Number(ex.preco || 0);
       linhas.push([ex.sku, ex.descricao || '', ex.qtd || 0, ex.preco ?? '', total || '', 'Excedente']);
@@ -74,7 +69,8 @@ export async function exportarPlanilha() {
   }
 
   const safe = (s) => String(s || '').replace(/[\\/:*?"<>|]/g, '-').slice(0, 80);
-  const filename = `conferencia_${safe(rz)}_${safe(lote)}_${new Date().toISOString().slice(0,10)}.xlsx`;
+  const stamp = new Date().toISOString().replace('T', '_').slice(0,16).replace(':','-');
+  const filename = `conferencia_${safe(lote)}_${safe(rz)}_${stamp}.xlsx`;
 
   XLSX.writeFile(book, filename);
 }

--- a/src/services/resetDb.js
+++ b/src/services/resetDb.js
@@ -1,0 +1,13 @@
+import { db } from '@/store/db';
+
+export async function resetAllData() {
+  try {
+    await db.transaction('rw', db.itens, db.excedentes, db.meta, async () => {
+      await db.itens.clear();
+      await db.excedentes.clear();
+      await db.meta.clear();
+    });
+  } catch {}
+  try { localStorage.clear(); } catch {}
+  try { sessionStorage.clear(); } catch {}
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,7 @@ h3{font-size:18px;margin:0}
 .badge{padding:4px 10px;border-radius:999px;font-weight:700;font-size:12px;background:#EEF2FF;color:#334155}
 .badge-ok{background:#EAFBF1;color:#14532D}
 .badge-falha{background:#FFF1F2;color:#7F1D1D}
+.version-badge{background:transparent;color:#6B7280;font-weight:400;font-size:12px}
 
 .input, select, input[type="number"], input[type="text"], input[type="range"], input[type="file"]{
   border:1px solid var(--border);border-radius:12px;padding:10px 12px;background:#fff;box-shadow:none;

--- a/src/utils/boot.js
+++ b/src/utils/boot.js
@@ -5,29 +5,35 @@ function getBootEl() {
 }
 
 /**
- * Mostra um toast e esconde automaticamente após `persistMs` (default 10s).
+ * Exibe um toast temporário com auto-hide de 10s.
+ * Pausa o temporizador ao passar o mouse e retoma ao sair.
  * @param {string} msg
- * @param {{level?: 'info'|'warn'|'error', persistMs?: number}} [opts]
+ * @param {{level?: 'info'|'warn'|'error'}} [opts]
  */
 export function updateBoot(msg, opts = {}) {
   const el = getBootEl();
   if (!el) return;
-  const { level = 'info', persistMs = 10000 } = opts;
+  const { level = 'info' } = opts;
 
   if (el.dataset) el.dataset.level = level;
-  el.innerHTML = msg;
-  el.classList?.remove('hidden');
+  const textEl = typeof el.querySelector === 'function' ? el.querySelector('.boot-text') : null;
+  if (textEl) textEl.textContent = msg;
 
-  // limpa timer anterior
-  if (hideTimer) {
-    clearTimeout(hideTimer);
-    hideTimer = null;
+  // limpa timer antigo
+  if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+
+  const onEnter = () => { if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; } };
+  const onLeave = () => { if (!hideTimer) hideTimer = setTimeout(() => el.classList.add('hidden'), 10_000); };
+
+  if (typeof el.removeEventListener === 'function') {
+    el.removeEventListener('mouseenter', onEnter);
+    el.removeEventListener('mouseleave', onLeave);
+    el.addEventListener('mouseenter', onEnter);
+    el.addEventListener('mouseleave', onLeave);
   }
 
-  // agenda auto-hide
-  hideTimer = setTimeout(() => {
-    el.classList?.add('hidden');
-  }, Math.max(0, persistMs));
+  el.classList?.remove?.('hidden');
+  hideTimer = setTimeout(() => el.classList?.add?.('hidden'), 10_000);
 }
 
 /** Esconde imediatamente o toast. */

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,11 @@ import path from 'path';
 export default defineConfig({
   base: '/',
   root: '.',
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION || ''),
+    __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT || ''),
+    __BRANCH__: JSON.stringify(process.env.VITE_BRANCH || ''),
+  },
   build: {
     // Gera bundle para engines modernas (TLA requer es2022+)
     target: ['es2022', 'chrome98', 'edge98', 'firefox102', 'safari15.4'],


### PR DESCRIPTION
## Summary
- show version badge with commit hash in header
- add DB reset service and toolbar button
- auto-hide boot toast with hover pause
- enrich Excel export with summary sheet and styled headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b982c6fa80832b87442cc0942f3f13