### PR TITLE
feat: switch to xlsx-js-style and style Excel header

### DIFF
--- a/src/services/exportExcel.js
+++ b/src/services/exportExcel.js
@@ -1,81 +1,41 @@
-import XLSX from 'xlsx-js-style';
 import { db, getMeta } from '../store/db.js';
+import { exportToExcel } from '../utils/excel.js';
 
-/**
- * Gera workbook com 3 abas: Conferidos, Pendentes, Excedentes.
- * Inclui metadados nas primeiras linhas (Lote, RZ, Data).
- */
+// Monta dados e delega exportação ao utilitário
 export async function exportarPlanilha() {
   const rz = await getMeta('rzAtual', '—');
   const lote = await getMeta('loteAtual', '—');
-  const agora = new Date().toLocaleString('pt-BR');
+  const now = new Date();
+  const dataStr = now.toLocaleString('pt-BR');
 
-  // cole seus dados das stores locais
   const conferidos = await db.itens.where('status').equals('Conferido').toArray();
   const pendentes  = await db.itens.where('status').equals('Pendente').toArray();
   const excedentes = await db.excedentes.toArray();
 
-  const book = XLSX.utils.book_new();
+  const linhas = [];
 
-  // helpers
-  const headerStyle = {
-    fill: { patternType: 'solid', fgColor: { rgb: 'FFA500' } }, // laranja
-    font: { bold: true, color: { rgb: '000000' } },
-    alignment: { vertical: 'center' }
+  const add = (arr, status, precoField) => {
+    arr.forEach(it => {
+      const preco = Number(it[precoField] || 0);
+      const qtd = Number(it.qtd || 0);
+      linhas.push({
+        SKU: it.sku,
+        Descrição: it.descricao || '',
+        Qtd: qtd,
+        Preço: preco || '',
+        Valor: preco * qtd,
+        Status: status,
+        Lote: lote,
+        RZ: rz,
+        Data: dataStr,
+      });
+    });
   };
-  const makeSheet = (linhas) => {
-    const ws = XLSX.utils.aoa_to_sheet(linhas);
-    // aplica estilo na primeira linha
-    const range = XLSX.utils.decode_range(ws['!ref'] || 'A1:A1');
-    for (let c = range.s.c; c <= range.e.c; c++) {
-      const addr = XLSX.utils.encode_cell({ r: 3, c }); // linha 4 (0-based) = cabeçalho
-      if (!ws[addr]) continue;
-      ws[addr].s = headerStyle;
-    }
-    ws['!rows'] = [{ hpt: 14 }, { hpt: 14 }, { hpt: 8 }, { hpt: 18 }]; // altura meta + header
-    return ws;
-  };
 
-  // 5.1) Conferidos
-  {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço Méd','Valor Total','Status']
-    ];
-    for (const it of conferidos) {
-      linhas.push([it.sku, it.descricao, it.qtd, it.precoMedio, it.valorTotal, 'Conferido']);
-    }
-    XLSX.utils.book_append_sheet(book, makeSheet(linhas), 'Conferidos');
-  }
+  add(conferidos, 'Conferido', 'precoMedio');
+  add(pendentes, 'Pendente', 'precoMedio');
+  add(excedentes, 'Excedente', 'preco');
 
-  // 5.2) Pendentes
-  {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço Méd','Valor Total','Status']
-    ];
-    for (const it of pendentes) {
-      linhas.push([it.sku, it.descricao, it.qtd, it.precoMedio, it.valorTotal, 'Pendente']);
-    }
-    XLSX.utils.book_append_sheet(book, makeSheet(linhas), 'Pendentes');
-  }
-
-  // 5.3) Excedentes
-  {
-    const linhas = [
-      ['Lote', lote], ['RZ', rz], ['Gerado em', agora],
-      ['SKU','Descrição','Qtd','Preço (R$)','Valor Total (R$)','Status']
-    ];
-    for (const ex of excedentes) {
-      const total = Number(ex.qtd || 0) * Number(ex.preco || 0);
-      linhas.push([ex.sku, ex.descricao || '', ex.qtd || 0, ex.preco ?? '', total || '', 'Excedente']);
-    }
-    XLSX.utils.book_append_sheet(book, makeSheet(linhas), 'Excedentes');
-  }
-
-  const safe = (s) => String(s || '').replace(/[\\/:*?"<>|]/g, '-').slice(0, 80);
-  const filename = `conferencia_${safe(rz)}_${safe(lote)}_${new Date().toISOString().slice(0,10)}.xlsx`;
-
-  XLSX.writeFile(book, filename);
+  exportToExcel(linhas, { lote, rz, date: now });
 }
 

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -1,4 +1,4 @@
-import * as XLSX from 'xlsx';
+import XLSX from 'xlsx-js-style';
 import { setRZs, setItens } from '../store/index.js';
 import { parseBRLLoose } from './number.js';
 import { startNcmQueue } from '../services/ncmQueue.js';
@@ -279,4 +279,26 @@ export function exportarConferencia({ conferidos, pendentes, excedentes, resumoR
   ]);
 
   XLSX.writeFile(wb, `conferencia_${new Date().toISOString().slice(0,10)}.xlsx`);
+}
+
+// Exporta dados simples aplicando estilo no cabeçalho
+export function exportToExcel(data, meta = {}) {
+  const ws = XLSX.utils.json_to_sheet(data);
+  const range = XLSX.utils.decode_range(ws['!ref'] || 'A1');
+  for (let c = range.s.c; c <= range.e.c; c++) {
+    const addr = XLSX.utils.encode_cell({ r: 0, c });
+    if (!ws[addr]) continue;
+    ws[addr].s = {
+      fill: { patternType: 'solid', fgColor: { rgb: 'FFA500' } },
+      font: { color: { rgb: 'FFFFFF' }, bold: true },
+      alignment: { horizontal: 'center', vertical: 'center' },
+    };
+  }
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Planilha');
+  const safe = s => String(s || '').replace(/[\\/:*?"<>|]/g, '-');
+  const { lote = '', rz = '', date = new Date() } = meta;
+  const timestamp = new Date(date).toISOString().replace(/[-:T]/g, '').split('.')[0];
+  const filename = `${safe(lote)}_${safe(rz)}_${timestamp}.xlsx`;
+  XLSX.writeFile(wb, filename);
 }

--- a/tests/excel.spec.js
+++ b/tests/excel.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import * as XLSX from 'xlsx';
+import XLSX from 'xlsx-js-style';
 vi.mock('../src/services/ncmQueue.js', () => ({ startNcmQueue: vi.fn() }));
 import { startNcmQueue } from '../src/services/ncmQueue.js';
 import { processarPlanilha } from '../src/utils/excel.js';

--- a/tests/export.spec.js
+++ b/tests/export.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import * as XLSX from 'xlsx';
+import XLSX from 'xlsx-js-style';
 import { exportarConferencia } from '../src/utils/excel.js';
 
 describe('exportarConferencia', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,9 +15,15 @@ export default defineConfig({
         ncm: path.resolve(__dirname, 'public/ncm.html'),
       },
     },
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
   },
   resolve: {
     alias: { '@': path.resolve(__dirname, 'src') },
+  },
+  optimizeDeps: {
+    include: ['xlsx-js-style'],
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- replace xlsx with xlsx-js-style in utilities
- add generic exportToExcel with styled header
- integrate export service and Vite config for xlsx-js-style

## Testing
- `npm test` *(fails: Failed to load url xlsx-js-style / dexie)*
- `npm run build` *(fails: [vite]: Rollup failed to resolve import "dexie")*

------
https://chatgpt.com/codex/tasks/task_e_68b98867fafc832b95f82700c6ce8bcc