### PR TITLE
Simplifica seletor de lote e integra atualização de importação

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             </div>
             <div class="field">
               <label for="select-lote" class="label">Lote</label>
-              <select id="select-lote" class="input" title="Lote ativo"></select>
+              <div id="lot-selector-host"></div>
             </div>
             <div class="field">
               <label class="label" for="btn-export">&nbsp;</label>

--- a/src/components/LotSelector.js
+++ b/src/components/LotSelector.js
@@ -1,18 +1,27 @@
 // src/components/LotSelector.js
-import { db, setSetting, getSetting } from '../store/db.js';
+import store from '@/store';
 
-export async function initLotSelector() {
-  const sel = document.getElementById('select-lote'); // adicione <select id="select-lote"></select> no HTML
-  if (!sel) return;
+export function initLotSelector() {
+  const host = document.getElementById('lot-selector-host');
+  if (!host) return;
 
-  const lots = await db.lots.orderBy('createdAt').reverse().toArray();
-  sel.innerHTML = lots.map(l => `<option value="${l.id}">${l.name} — ${l.rz || 'RZ ?'}</option>`).join('');
+  const lotes = store.selectLotes ? store.selectLotes() : [];
+  const current = store.selectLote?.() || lotes[0] || '';
 
-  const active = await getSetting('activeLotId', lots[0]?.id);
-  if (active) sel.value = String(active);
+  if (lotes.length <= 1) {
+    host.innerHTML = `<input type="hidden" id="select-lote" value="${current}">`;
+    return;
+  }
 
-  sel.addEventListener('change', async () => {
-    await setSetting('activeLotId', Number(sel.value));
-    location.reload(); // simples e robusto — recarrega o app já pegando o novo lotId
-  });
+  host.innerHTML = `
+    <select id="select-lote" class="input">
+      ${lotes.map(l => `<option ${l===current?'selected':''}>${l}</option>`).join('')}
+    </select>
+  `;
+}
+
+export function setCurrentLote(filename) {
+  const el = document.getElementById('select-lote');
+  if (el) el.value = filename;
+  if (store.setLote) store.setLote(filename);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import './styles.css';
 import { initImportPanel } from './components/ImportPanel.js';
+import { initLotSelector } from './components/LotSelector.js';
 import { mountKpis } from '@/components/Kpis';
 import { updateBoot } from './utils/boot.js';
 import { exportWorkbook } from './services/exportExcel.js';
@@ -10,6 +11,7 @@ import store from './store/index.js';
 window.__resetDb = resetAll;
 
 window.addEventListener('DOMContentLoaded', () => {
+  initLotSelector();
   initImportPanel();
   updateBoot('Boot: aplicativo carregado. Selecione a planilha e o RZ para iniciar.');
 

--- a/src/services/importer.js
+++ b/src/services/importer.js
@@ -1,5 +1,6 @@
 // src/services/importer.js
 import { db, setSetting } from '../store/db.js';
+import { setCurrentLote } from '../components/LotSelector.js';
 
 const META_KEY = 'confApp.meta.v1';
 
@@ -20,7 +21,10 @@ export function loadMeta() {
 export function wireLotFileCapture(inputEl) {
   inputEl?.addEventListener('change', () => {
     const file = inputEl.files?.[0];
-    if (file) saveMeta({ loteName: file.name });
+    if (file) {
+      saveMeta({ loteName: file.name });
+      setCurrentLote(file.name);
+    }
   });
 }
 


### PR DESCRIPTION
## Resumo
- Substitui seletor de lote por componente dinâmico que exibe dropdown apenas quando necessário
- Atualiza lote atual ao importar arquivo e inicializa seletor na carga da página

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b996319e00832ba449a874352f9043