### PR TITLE
Add health check modal and build adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         </label>
         <button id="helpBtn" title="Ajuda/Atalhos" aria-label="Ajuda" class="btn btn-ghost">?</button>
         <button id="btn-download-backup" class="btn btn-ghost">Baixar backup</button>
+        <button id="btn-health" class="btn btn-ghost">Health</button>
       </div>
     </header>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   command = "npm run build"
   publish = "dist"
 
+[build.environment]
+  NODE_VERSION = "18"
+
 [[headers]]
   for = "/assets/*"
   [headers.values]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run --reporter=dot --silent",
-    "test:verbose": "cross-env VERBOSE=1 vitest run --reporter=verbose"
+    "test:verbose": "cross-env VERBOSE=1 vitest run --reporter=verbose",
+    "health": "echo 'Abra o app em http://localhost:5173/?nocache=1 e veja \"HEALTH MODE\" no console'",
+    "reset-data": "node scripts/reset-data.js"
   },
   "dependencies": {
     "@zxing/browser": "^0.1.5",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,12 @@
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', event => {
+  event.waitUntil((async () => {
+    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    if (clients.some(c => c.url.includes('nocache=1'))) {
+      await self.registration.unregister();
+      return;
+    }
+    await self.clients.claim();
+  })());
+});

--- a/scripts/reset-data.js
+++ b/scripts/reset-data.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('Abra o app no navegador e use o botão "Zerar dados" ou execute resetStorage() no console.');

--- a/src/components/HealthModal.css
+++ b/src/components/HealthModal.css
@@ -1,0 +1,5 @@
+.health-modal { padding: 16px; }
+.health-modal ul { list-style: none; padding: 0; }
+.health-modal li { margin: 8px 0; }
+.health-modal .status-ok { color: var(--success, #22C55E); }
+.health-modal .status-fail { color: var(--danger, #EF4444); }

--- a/src/components/HealthModal.js
+++ b/src/components/HealthModal.js
@@ -1,0 +1,39 @@
+import './HealthModal.css';
+import { runHealthChecks, resetStorage } from '../utils/health.js';
+
+export function initHealthModal() {
+  const btn = document.getElementById('btn-health') || (() => {
+    const actions = document.querySelector('.toolbar .actions');
+    if (!actions) return null;
+    const b = document.createElement('button');
+    b.id = 'btn-health';
+    b.className = 'btn btn-ghost';
+    b.textContent = 'Health';
+    actions.appendChild(b);
+    return b;
+  })();
+  if (!btn) return;
+
+  const dlg = document.createElement('dialog');
+  dlg.id = 'dlg-health';
+  dlg.className = 'health-modal';
+  dlg.innerHTML = '<h2>Health Check</h2><div id="health-content"></div><form method="dialog"><button class="btn">Fechar</button></form>';
+  document.body.appendChild(dlg);
+
+  btn.addEventListener('click', async () => {
+    const res = await runHealthChecks();
+    const body = dlg.querySelector('#health-content');
+    const items = [];
+    items.push(`<li>Ícones: <span class="${res.icons.ok ? 'status-ok' : 'status-fail'}">${res.icons.ok ? '✅' : '❌'}</span></li>`);
+    if (res.dexie.ok) {
+      items.push('<li>Dexie: <span class="status-ok">✅</span></li>');
+    } else {
+      items.push('<li>Dexie: <span class="status-fail">❌</span> <button id="btn-reset-storage" class="btn btn-ghost">Zerar dados</button></li>');
+    }
+    body.innerHTML = `<ul>${items.join('')}</ul>`;
+    body.querySelector('#btn-reset-storage')?.addEventListener('click', () => {
+      resetStorage();
+    });
+    dlg.showModal();
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import './styles.css';
 import { initImportPanel } from './components/ImportPanel.js';
 import { initLotSelector } from './components/LotSelector.js';
+import { initHealthModal } from './components/HealthModal.js';
 import { getCurrentLotId, countByStatus, getItemsByLotAndStatus, clearAll } from './store/db.js';
 
 async function renderPendentes(lotId) {
@@ -47,5 +48,6 @@ window.resetAllData = async () => { await clearAll(); window.location.reload(); 
 window.addEventListener('DOMContentLoaded', async () => {
   await initLotSelector();
   initImportPanel();
+  initHealthModal();
   refreshAll();
 });

--- a/src/utils/health.js
+++ b/src/utils/health.js
@@ -1,0 +1,69 @@
+import db from '../store/db.js';
+
+export async function checkIcons() {
+  const nodes = [...document.querySelectorAll('use')];
+  const okHref = nodes.every(u => (u.getAttribute('href') || '').startsWith('icons.svg#'));
+  const iconsOk = await fetch('icons.svg', { cache: 'no-store' })
+    .then(r => r.ok)
+    .catch(() => false);
+  return { ok: okHref && iconsOk, okHref, iconsOk };
+}
+
+export async function checkDexie() {
+  const has = !!window.indexedDB;
+  let opened = false, stores = [], error = null;
+  if (has) {
+    try {
+      if (!db.isOpen()) await db.open();
+      opened = true;
+      stores = db.tables?.map(t => t.name) || [];
+      db.close();
+    } catch (e) {
+      error = String(e);
+    }
+  }
+  return { ok: has && opened && !error, has, opened, stores, error };
+}
+
+export async function resetStorage() {
+  if (window.indexedDB?.databases) {
+    const dbs = await indexedDB.databases();
+    await Promise.all(
+      dbs.map(d => new Promise(res => {
+        const req = indexedDB.deleteDatabase(d.name);
+        req.onsuccess = req.onerror = req.onblocked = () => res();
+      }))
+    );
+  }
+  localStorage.clear();
+  sessionStorage.clear();
+  if (window.caches?.keys) {
+    const keys = await caches.keys();
+    await Promise.all(keys.map(k => caches.delete(k)));
+  }
+  location.replace(location.pathname + '?nocache=1');
+}
+
+export async function runHealthChecks() {
+  const [icons, dexie] = await Promise.all([
+    checkIcons(),
+    checkDexie()
+  ]);
+  const result = { icons, dexie };
+  window.__HEALTH__ = result;
+  console.log('window.__HEALTH__', result);
+  return result;
+}
+
+if ('serviceWorker' in navigator) {
+  if (location.search.includes('nocache=1')) {
+    navigator.serviceWorker.getRegistrations().then(list => list.forEach(r => r.unregister()));
+  } else {
+    navigator.serviceWorker.register('sw.js');
+  }
+}
+
+if (location.search.includes('nocache=1')) {
+  console.log('HEALTH MODE');
+  runHealthChecks();
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,10 +5,8 @@ export default defineConfig({
   base: '/',
   root: '.',
   build: {
-    // Gera bundle para engines modernas (TLA requer es2022+)
-    target: ['es2022', 'chrome98', 'edge98', 'firefox102', 'safari15.4'],
-    // Opcional: garante que o esbuild não “rebaixe” TLA
-    // esbuild: { supported: { 'top-level-await': true } },
+    // Bundle gerado para engines compatíveis com ES2020
+    target: 'es2020',
     rollupOptions: {
       input: {
         main: path.resolve(__dirname, 'index.html'),


### PR DESCRIPTION
## Summary
- configure build target for ES2020 and set Netlify Node 18
- add service worker and health check modal with Dexie/icons diagnostics
- include maintenance scripts for health mode and data reset

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1d0c83a4832ba04ec5d046133ead