### PR TITLE
fix(build): force browser ESM for xlsx-js-style and add shims for Node modules

### DIFF
--- a/src/services/exportExcel.js
+++ b/src/services/exportExcel.js
@@ -1,4 +1,4 @@
-import XLSX from 'xlsx-js-style';
+import * as XLSX from 'xlsx-js-style/dist/xlsx.mjs';
 
 function headerRow(headers) {
   return headers.map(h => ({
@@ -62,6 +62,15 @@ export function exportWorkbook({ conferidos, pendentes, excedentes, meta }) {
   const safeLote = (lote || 'lote').replace(/[^\w\-]+/g, '_');
   const filename = `conferencia_${safeLote}_${y}-${m}-${d}.xlsx`;
 
-  XLSX.writeFile(wb, filename, { compression: true });
+  const wbout = XLSX.write(wb, { bookType: 'xlsx', type: 'array', compression: true });
+  const blob = new Blob([wbout], { type: 'application/octet-stream' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
 }
 

--- a/src/shims/empty.js
+++ b/src/shims/empty.js
@@ -1,0 +1,4 @@
+export default {};
+export const Readable = {};
+export const Writable = {};
+export const Transform = {};

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,17 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: { '@': path.resolve(__dirname, 'src') },
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      stream: path.resolve(__dirname, 'src/shims/empty.js'),
+      fs: path.resolve(__dirname, 'src/shims/empty.js'),
+      crypto: path.resolve(__dirname, 'src/shims/empty.js'),
+      util: path.resolve(__dirname, 'src/shims/empty.js'),
+      buffer: path.resolve(__dirname, 'src/shims/empty.js'),
+    },
+  },
+  optimizeDeps: {
+    include: ['xlsx-js-style/dist/xlsx.mjs'],
   },
   server: {
     proxy: {


### PR DESCRIPTION
Evita dependências de Node no bundle do navegador e elimina o erro de stream.Readable. Export Excel continua funcionando via Blob.

------
https://chatgpt.com/codex/tasks/task_e_68ba498456b0832bb29d3054b1478bda