### PR TITLE
Padroniza status checked nos registros

### DIFF
--- a/src/components/ResultsPanel.js
+++ b/src/components/ResultsPanel.js
@@ -57,7 +57,8 @@ export function renderResults(){
       tbConf.innerHTML = confRows.length
         ? confRows.map(r=>{
             const badgeCls = r.status === 'avariado' ? 'badge-excedente' : 'badge-conferido';
-            const label = r.status ? r.status.charAt(0).toUpperCase() + r.status.slice(1) : 'Conferido';
+            const labelMap = { checked: 'Conferido', avariado: 'Avariado' };
+            const label = r.status ? (labelMap[r.status] || r.status.charAt(0).toUpperCase() + r.status.slice(1)) : 'Conferido';
             return `<tr data-sku="${r.sku}" class="row-conferido${r.status==='avariado'?' avariado':''}"><td class="sticky">${r.sku}</td><td>${r.descricao}</td><td class="num">${r.qtd}</td><td class="num">${r.preco.toFixed(2)}</td><td class="num">${r.total.toFixed(2)}</td><td><span class="badge ${badgeCls}">${label}</span></td></tr>`;
           }).join('')
         : `<tr><td colspan="6" style="text-align:center;color:#777">Nenhum item conferido</td></tr>`;

--- a/src/services/loteDb.js
+++ b/src/services/loteDb.js
@@ -8,7 +8,8 @@ export async function markAsConferido(sku, patch = {}) {
   const row = await db.items.where({ lotId, sku }).first();
   if (!row) return;
 
-  await db.items.update(row.id, { status: 'conferido', ...patch });
+  // Usa "checked" como status padrão, permitindo sobrescrita via patch
+  await db.items.update(row.id, { status: 'checked', ...patch });
 }
 
 export async function addExcedente({ sku, descricao, qtd, preco }) {


### PR DESCRIPTION
## Summary
- salva conferências com status `checked` em vez de `conferido`
- mantém compatibilidade com dados antigos ao contar/listar itens
- exibe rótulo correto para itens com status `checked`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba51baea8c832ba041369bd67ba6e8