### PR TITLE
feat: restore enter flow for sku input

### DIFF
--- a/tests/actions-enter-flow.spec.js
+++ b/tests/actions-enter-flow.spec.js
@@ -69,4 +69,16 @@ describe('enter flow', () => {
     input.dispatchEvent({ type:'keydown', key:'Enter', ctrlKey:true, preventDefault: () => {} });
     expect(spy).toHaveBeenCalled();
   });
+
+  it('Second Enter after consulta triggers Registrar', () => {
+    store.findInRZ = () => ({ qtd:1, precoMedio:10 });
+    const spy = vi.spyOn(store, 'conferir').mockImplementation(() => {});
+    input.value = 'AAA';
+    elements['preco-ajustado'].value = '1';
+    // Primeiro Enter consulta
+    input.dispatchEvent({ type:'keydown', key:'Enter', preventDefault: () => {} });
+    // Segundo Enter registra
+    input.dispatchEvent({ type:'keydown', key:'Enter', preventDefault: () => {} });
+    expect(spy).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- reinstate Enter key flow for SKU field using a keydown listener and internal state toggle
- ensure buttons remain clickable and add tests for double-enter registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba5661d354832b8feb7c78facf6fc5