### PR TITLE
Padroniza campo descricao para excedentes

### DIFF
--- a/src/components/ExcedenteDialog.js
+++ b/src/components/ExcedenteDialog.js
@@ -31,20 +31,20 @@ export function wireExcedenteDialog() {
   form?.addEventListener('submit', (e) => {
     e.preventDefault();
     const sku   = document.getElementById('exc-sku')?.value?.trim();
-    const desc  = document.getElementById('exc-desc')?.value?.trim();
+    const descricao  = document.getElementById('exc-desc')?.value?.trim();
     const qtd   = Number(document.getElementById('exc-qtd')?.value || 0);
     const preco = document.getElementById('exc-preco')?.value; // opcional
     const obs   = document.getElementById('exc-obs')?.value?.trim();
 
     if (!sku)  { updateBoot('SKU inválido'); return; }
-    if (!desc) { updateBoot('Informe a descrição'); inputs[0]?.focus(); return; }
+    if (!descricao) { updateBoot('Informe a descrição'); inputs[0]?.focus(); return; }
     if (!(qtd >= 1)) { updateBoot('Qtd deve ser ≥ 1'); inputs[1]?.focus(); return; }
 
-    const reg = { sku, descricao: desc, qtd, preco_unit: (preco === '' ? null : Number(preco)), obs };
+    const reg = { sku, descricao, qtd, preco_unit: (preco === '' ? null : Number(preco)), obs };
     saveExcedente(reg);
 
     try { dlg.close(); } catch {}
-    updateBoot(`Excedente salvo: ${sku} • ${desc}`);
+    updateBoot(`Excedente salvo: ${sku} • ${descricao}`);
 
     // atualiza a lista/contadores imediatamente (ajuste para seus renders)
     if (typeof window.refreshExcedentesTable === 'function') window.refreshExcedentesTable();

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -136,7 +136,7 @@ function rowsConferidos() {
   })();
   return items.map(it => ({
     SKU: it.sku,
-    Descrição: it.descricao || it.desc || '',
+    Descrição: it.descricao || '',
     Qtd: it.qtd || it.quantidade || 0,
     'Preço Médio (R$)': it.preco_ml_unit ?? it.preco ?? 0,
     'Valor Total (R$)': (Number(it.qtd || 0) * Number(it.preco_ml_unit ?? it.preco ?? 0)).toFixed(2),
@@ -152,7 +152,7 @@ function rowsPendentes() {
   const exc = new Set(rowsExcedentes().map(r => r.SKU));
   return all.filter(x => !conf.has(x.sku) && !exc.has(x.sku)).map(it => ({
     SKU: it.sku,
-    Descrição: it.descricao || it.desc || '',
+    Descrição: it.descricao || '',
     Qtd: it.qtd || it.quantidade || 0,
     'Preço Médio (R$)': it.preco_ml_unit ?? it.preco ?? 0,
     'Valor Total (R$)': (Number(it.qtd || 0) * Number(it.preco_ml_unit ?? it.preco ?? 0)).toFixed(2),
@@ -167,7 +167,7 @@ function rowsExcedentes() {
   })();
   return local.map(ex => ({
     SKU: ex.sku,
-    Descrição: ex.descricao || ex.desc || '',
+    Descrição: ex.descricao || '',
     Qtd: ex.qtd || 0,
     'Preço Unitário (R$)': ex.preco_unit ?? '',
     'Valor Total (R$)': (ex.preco_unit == null ? '' : (Number(ex.preco_unit) * Number(ex.qtd || 0)).toFixed(2)),

--- a/src/services/loteDb.js
+++ b/src/services/loteDb.js
@@ -18,7 +18,7 @@ export async function addExcedente({ sku, descricao, qtd, preco }) {
   await db.items.add({
     lotId,
     sku,
-    desc: descricao || '',
+    descricao: descricao || '',
     qtd: Number(qtd || 1),
     precoMedio: Number(preco || 0),
     valorTotal: Number((preco || 0) * (qtd || 1)),


### PR DESCRIPTION
## Summary
- padroniza uso do campo `descricao` ao exportar itens e excedentes
- ajusta diálogo e persistência para salvar excedentes com `descricao`
- grava excedentes no IndexedDB usando `descricao`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba58f2256c832bac9f10c17498e1c8