### PR TITLE
Integrate spreadsheet service with database

### DIFF
--- a/src/services/planilha.js
+++ b/src/services/planilha.js
@@ -1,0 +1,44 @@
+import { processarPlanilha as parseAndStore } from '../utils/excel.js';
+import { addLot, setCurrentLotId, addItemsBulk, setSetting } from '../store/db.js';
+
+/**
+ * Processa uma planilha Excel e persiste os itens no banco Dexie.
+ * Reexporta processarPlanilha de utils/excel.js adicionando integração
+ * com o banco, similar ao antigo importer.js.
+ *
+ * @param {File|ArrayBuffer|Uint8Array} file - arquivo ou buffer da planilha
+ * @param {string} rz - código de RZ selecionado
+ * @returns {Promise<object>} resultado de parseAndStore
+ */
+export async function processarPlanilha(file, rz = '') {
+  // Executa parsing e popula o store em memória
+  const result = await parseAndStore(file);
+
+  // Cria novo lote e define como atual
+  const lotId = await addLot({ name: file?.name || 'planilha.xlsx', rz });
+  setCurrentLotId(lotId);
+  await setSetting('activeLotId', lotId);
+
+  // Converte os totais agregados em itens individuais para o Dexie
+  const items = [];
+  const totalMap = result.totalByRZSku || {};
+  const metaMap = result.metaByRZSku || {};
+  for (const [rzKey, skuMap] of Object.entries(totalMap)) {
+    for (const [sku, qtd] of Object.entries(skuMap)) {
+      const meta = metaMap[rzKey]?.[sku] || {};
+      items.push({
+        sku,
+        descricao: meta.descricao || '',
+        qtd,
+        preco: meta.precoMedio || 0,
+        status: 'pending',
+      });
+    }
+  }
+
+  if (items.length) {
+    await addItemsBulk(lotId, items);
+  }
+
+  return result;
+}

--- a/tests/actions-focus.spec.js
+++ b/tests/actions-focus.spec.js
@@ -10,10 +10,13 @@ function createEl(tag = 'input') {
   const el = {
     tagName: tag.toUpperCase(),
     value: '',
+    innerHTML: '',
     classList: { add: () => {}, remove: () => {} },
     focus() { document.activeElement = this; },
     select() { this._selected = true; },
     addEventListener(type, fn) { (el._l ||= {})[type] = fn; },
+    appendChild: () => {},
+    removeChild: () => {},
     click() { el._l?.click?.({}); },
     dispatchEvent(ev) { el._l?.[ev.type]?.(ev); },
     setAttribute: () => {},

--- a/tests/import-panel.spec.js
+++ b/tests/import-panel.spec.js
@@ -1,9 +1,8 @@
 import { describe, it, beforeEach, expect, vi } from 'vitest';
-vi.mock('../src/utils/excel.js', () => ({ parsePlanilha: vi.fn() }));
-vi.mock('../src/services/ncmQueue.js', () => ({ startNcmQueue: vi.fn() }));
+vi.mock('../src/services/planilha.js', () => ({ processarPlanilha: vi.fn() }));
 vi.mock('../src/utils/ui.js', () => ({ loadSettings: () => ({ resolveNcm: false }), renderCounts: vi.fn(), renderExcedentes: vi.fn() }));
 import { initImportPanel } from '../src/components/ImportPanel.js';
-import { parsePlanilha } from '../src/utils/excel.js';
+import { processarPlanilha } from '../src/services/planilha.js';
 import store from '../src/store/index.js';
 import { toast } from '../src/utils/toast.js';
 
@@ -42,7 +41,7 @@ describe('ImportPanel error handling', () => {
   });
 
   it('emits toast.error and keeps state when parse fails', async () => {
-    parsePlanilha.mockRejectedValue(new Error('fail'));
+    processarPlanilha.mockRejectedValue(new Error('fail'));
     const spy = vi.spyOn(toast, 'error').mockImplementation(() => {});
     const file = { name: 'x.xlsx', arrayBuffer: async () => new ArrayBuffer(0) };
     await fileEl._l.change({ target: { files: [file] } });


### PR DESCRIPTION
## Summary
- add planilha service that processes spreadsheets and stores items in Dexie
- update tests to mock new service and improve DOM stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c010233754832b96c60293180d8378