### PR TITLE
Validate identifiers in NCM queue

### DIFF
--- a/src/services/ncmQueue.js
+++ b/src/services/ncmQueue.js
@@ -11,7 +11,18 @@ export async function startNcmQueue(items = []){
   cancelled = false;
   const pending = items
     .filter(it => !it.ncm)
-    .map(it => ({ id: `${it.codigoRZ}:${it.codigoML}`, it }));
+    .map(it => {
+      const rz = String(it.codigoRZ || '').trim().toUpperCase();
+      const sku = String(it.codigoML || '').trim().toUpperCase();
+      if(!rz || !sku){
+        console.warn('Item sem codigoRZ/codigoML, ignorando', it);
+        return null;
+      }
+      it.codigoRZ = rz;
+      it.codigoML = sku;
+      return { id: `${rz}:${sku}`, it };
+    })
+    .filter(Boolean);
 
   const total = pending.length;
   let done = 0;

--- a/tests/ncmQueue.spec.js
+++ b/tests/ncmQueue.spec.js
@@ -34,4 +34,18 @@ describe('ncmQueue', () => {
     expect(flag).toBe(true);
     await p;
   });
+
+  it('skips items without identifiers', async () => {
+    resolveNcmByDescription.mockResolvedValue({ ncm:'1', status:'ok' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const items = [
+      { codigoRZ:'RZ', codigoML:'A', descricao:'', ncm:null },
+      { codigoRZ:'', codigoML:'B', descricao:'', ncm:null },
+      { codigoRZ:'RZ', codigoML:'', descricao:'', ncm:null },
+    ];
+    await startNcmQueue(items);
+    expect(resolveNcmByDescription).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- normalize and verify RZ/SKU codes before enqueuing
- add test for items lacking identifiers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c04aca075c832baf32009605ab9709