### PR TITLE
Clarify responsibilities of similarly named modules

### DIFF
--- a/netlify/functions/ncm.js
+++ b/netlify/functions/ncm.js
@@ -1,3 +1,4 @@
+// Netlify function proxying NCM API requests
 export async function handler(evt) {
   const url = new URL(evt.rawUrl);
   const q = url.searchParams.get('descricao') || url.searchParams.get('codigo');

--- a/public/ncm.html
+++ b/public/ncm.html
@@ -62,6 +62,6 @@
     </thead>
     <tbody></tbody>
   </table>
-  <script type="module" src="/src/pages/ncm/main.js"></script>
+  <script type="module" src="/src/pages/ncm/ncmConsole.js"></script>
 </body>
 </html>

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -1,7 +1,7 @@
 // src/components/ActionsPanel.js
 import { exportarConferencia } from '../utils/excel.js';
 import store, { findConferido, findEmOutrosRZ, moveItemEntreRZ } from '../store/index.js';
-import { loadFinanceConfig, saveFinanceConfig } from '../utils/finance.js';
+import { loadFinanceConfig, saveFinanceConfig } from '../utils/financeUtils.js';
 import { loadPrefs, savePrefs } from '../utils/prefs.js';
 import { toast } from '../utils/toast.js';
 import { openExcedenteModal } from './ExcedenteModal.js';

--- a/src/components/Indicators.js
+++ b/src/components/Indicators.js
@@ -6,7 +6,7 @@ import {
   saveMetricsPrefs,
   computeItemFinance,
   computeAggregates,
-} from '../utils/finance.js';
+} from '../utils/financeUtils.js';
 import { loadPrefs, savePrefs } from '../utils/prefs.js';
 import { updateBoot } from '../utils/boot.js';
 

--- a/src/config/financeConfig.js
+++ b/src/config/financeConfig.js
@@ -1,3 +1,4 @@
+// Default finance configuration values
 export const FINANCE = {
   percent_pago_sobre_ml: 0.20,     // pagamos 20% do preço médio ML
   desconto_venda_vs_ml:  0.20,     // vendemos 20% abaixo do preço médio ML

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+// Main application entry point
 import './styles.css';
 import { init } from './store/index.js';
 import { startNcmQueue } from './services/ncmQueue.js';

--- a/src/ncmClient.js
+++ b/src/ncmClient.js
@@ -1,3 +1,4 @@
+// Client-side utilities for manual NCM operations
 import { NCM_CACHE_KEY } from './config/runtime.js';
 import { resolve, normalizeNCM, slug, cacheSet } from './services/ncmService.js';
 import { startNcmQueue } from './services/ncmQueue.js';

--- a/src/pages/ncm/ncmConsole.js
+++ b/src/pages/ncm/ncmConsole.js
@@ -1,3 +1,4 @@
+// Entry point for the NCM console page
 import { RUNTIME, NCM_CACHE_KEY } from '../../config/runtime.js';
 import * as ncmSvc from '../../services/ncmService.js';
 import { startNcmQueue } from '../../services/ncmQueue.js';

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -1,4 +1,5 @@
-import { FINANCE } from '../config/finance.js';
+// Utilities for finance configuration and calculations
+import { FINANCE } from '../config/financeConfig.js';
 
 export const FINANCE_KEY = 'config:finance:v1';
 export const METRICS_PREFS_KEY = 'ui:metricsPrefs:v1';

--- a/tests/Indicators.spec.js
+++ b/tests/Indicators.spec.js
@@ -7,7 +7,7 @@ vi.mock('../src/utils/prefs.js', () => ({
   savePrefs: vi.fn(),
 }));
 
-vi.mock('../src/utils/finance.js', () => ({
+vi.mock('../src/utils/financeUtils.js', () => ({
   loadFinanceConfig: vi.fn(() => ({ frete_total: 0, rateio_frete: 'valor', percent_pago_sobre_ml: 0.2, desconto_venda_vs_ml: 0.1 })),
   loadMetricsPrefs: vi.fn(() => ({ visible: { preco_medio_ml_palete: true } })),
   saveMetricsPrefs: vi.fn(),

--- a/tests/finance.spec.js
+++ b/tests/finance.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { computeFreteUnit, computeItemFinance, loadMetricsPrefs, saveMetricsPrefs } from '../src/utils/finance.js';
+import { computeFreteUnit, computeItemFinance, loadMetricsPrefs, saveMetricsPrefs } from '../src/utils/financeUtils.js';
 
 describe('finance computations', () => {
   it('base case quantity rateio', () => {


### PR DESCRIPTION
## Summary
- rename finance modules to `financeConfig` and `financeUtils` and update imports
- rename NCM console entry point to `ncmConsole` and adjust HTML
- add explicit documentation comments for main app, NCM client, and Netlify NCM function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04d0b4828832b9c638db17a936a93