### PR TITLE
chore(debug): add RZ tracing (store, select binding, boot) with conditional activation

### DIFF
--- a/src/debug/logger.js
+++ b/src/debug/logger.js
@@ -1,0 +1,25 @@
+// src/debug/logger.js
+const on = () => (/\bdebug=1\b/.test(location.search) || localStorage.DEBUG_RZ === '1');
+
+export function createLogger(ns='APP'){
+  const enabled = on();
+  const tag = (lvl) => `%c${new Date().toISOString()} %c[${ns}] %c${lvl}`;
+  const css = (color)=>['color:#999','color:#6a5acd;font-weight:bold',`color:${color};font-weight:bold`];
+
+  function log(lvl,color,...args){
+    if(!enabled) return;
+    // eslint-disable-next-line no-console
+    console.log(tag(lvl), ...css(color), ...args);
+  }
+  return {
+    enabled,
+    debug: (...a)=>log('DEBUG','#4caf50',...a),
+    info : (...a)=>log('INFO' ,'#2196f3',...a),
+    warn : (...a)=>log('WARN' ,'#ff9800',...a),
+    error: (...a)=>log('ERROR','#f44336',...a),
+    group: (title)=> on() && console.groupCollapsed?.(`[${ns}] ${title}`),
+    groupEnd: ()=> on() && console.groupEnd?.()
+  };
+}
+
+export function isDebug(){ return on(); }

--- a/src/debug/overlay.js
+++ b/src/debug/overlay.js
@@ -1,0 +1,13 @@
+// simples overlay no canto para ver RZ atual e contagem
+export function mountRzOverlay(getState){
+  const el = document.createElement('div');
+  el.style = 'position:fixed;left:8px;bottom:8px;padding:6px 8px;background:#111;color:#fff;font:12px/1.3 ui-monospace;border-radius:6px;opacity:.85;z-index:99999';
+  document.body.appendChild(el);
+  const tick = ()=>{
+    const st = getState();
+    el.textContent = `RZ=${st.rz ?? '(null)'} | itens=${st.total} | doRZ=${st.doRZ}`;
+  };
+  tick();
+  const id = setInterval(tick, 800);
+  return ()=>clearInterval(id);
+}

--- a/src/debug/traceRZ.js
+++ b/src/debug/traceRZ.js
@@ -1,0 +1,164 @@
+// src/debug/traceRZ.js
+import store from '../store/index.js';
+import { createLogger, isDebug } from './logger.js';
+import { mountRzOverlay } from './overlay.js';
+
+const log = createLogger('RZ');
+
+let boundAbort = null;
+
+function findSelect(){
+  return document.getElementById('select-rz')
+      || document.getElementById('rz')
+      || document.querySelector('select[name="rz"]')
+      || document.querySelector('[data-rz]');
+}
+
+function bindSelectOnce(){
+  const sel = findSelect();
+  if(!sel){ log.warn('Select RZ não encontrado ainda'); return false; }
+  if(sel.dataset.rzBound === '1'){ log.debug('Select RZ já está bound'); return true; }
+
+  boundAbort?.abort?.();
+  const ac = new AbortController();
+  boundAbort = ac;
+  sel.addEventListener('change', ()=>{
+    const before = store?.state?.currentRZ ?? null;
+    const after = sel.value;
+    log.group(`UI change -> setCurrentRZ("${after}")`);
+    log.debug('ANTES', { currentRZ: before });
+    try {
+      store.setCurrentRZ?.(after);
+      store.emit?.('refresh');
+      log.info('DEPOIS', { currentRZ: store?.state?.currentRZ ?? null });
+    } catch(e){
+      log.error('Falha ao setar RZ via UI', e);
+    } finally {
+      log.groupEnd();
+    }
+  }, { signal: ac.signal });
+
+  // sincroniza valores
+  const st = store?.state?.currentRZ ?? '';
+  if(st){ sel.value = st; }
+  else if(sel.value){ 
+    log.info('State sem RZ; adotando o do select inicial', sel.value);
+    store.setCurrentRZ?.(sel.value);
+    store.emit?.('refresh');
+  }
+
+  sel.dataset.rzBound = '1';
+  log.info('RZ select bound', { value: sel.value, id: sel.id || '(sem id)' });
+  return true;
+}
+
+function watchSelectAppearance(ms=3000){
+  if(bindSelectOnce()) return;
+  const obs = new MutationObserver(()=>{
+    if(bindSelectOnce()) obs.disconnect();
+  });
+  obs.observe(document.documentElement, { childList:true, subtree:true });
+  setTimeout(()=>obs.disconnect(), ms);
+}
+
+function patchStore(){
+  if(!store) return;
+  if(store.__rzPatched) return;
+  store.__rzPatched = true;
+
+  const origSet = store.setCurrentRZ?.bind(store);
+  if(origSet){
+    store.setCurrentRZ = (rz)=>{
+      const before = store?.state?.currentRZ ?? null;
+      log.group(`store.setCurrentRZ("${rz}")`);
+      log.debug('ANTES', { currentRZ: before });
+      const ret = origSet(rz);
+      log.info('DEPOIS', { currentRZ: store?.state?.currentRZ ?? null });
+      log.groupEnd();
+      return ret;
+    };
+  }
+
+  const wrapMut = (name)=>{
+    const fn = store[name]?.bind(store);
+    if(!fn) return;
+    store[name] = (...args)=>{
+      const rz = store?.state?.currentRZ ?? null;
+      log.group(`${name}() @rz=${rz}`);
+      try { 
+        const out = fn(...args);
+        const items = store?.state?.items || [];
+        log.info('itens no state', { total: items.length, rzAtual: rz, doRZ: items.filter(i=>i?.rz===rz).length });
+        return out;
+      } catch(e){
+        log.error(`${name} falhou`, e);
+      } finally {
+        log.groupEnd();
+      }
+    };
+  };
+
+  ['upsertItem','bulkUpsertItems','updateItem'].forEach(wrapMut);
+
+  const origEmit = store.emit?.bind(store);
+  if(origEmit){
+    store.emit = (evt, ...rest)=>{
+      const rz = store?.state?.currentRZ ?? null;
+      log.debug(`emit("${evt}") @rz=${rz}`, ...rest);
+      return origEmit(evt, ...rest);
+    };
+  }
+
+  const origOn = store.on?.bind(store);
+  if(origOn){
+    store.on = (evt, fn)=>{
+      log.debug(`on("${evt}") registrado`);
+      return origOn(evt, fn);
+    };
+  }
+}
+
+function patchBoot(){
+  const bootEl = document.getElementById('boot') || document.querySelector('.boot-badge,[data-boot]');
+  if(bootEl){
+    const origText = bootEl.textContent;
+    log.debug('Boot badge detectado', { text: origText });
+  }
+  const g = (p)=> (typeof p === 'function' ? p : ()=>{});
+  try {
+    const mod = require('../utils/boot.js'); // Vite resolverá ESM; fica só como dica
+    const show = g(mod.showBoot), hide = g(mod.hideBoot);
+    mod.showBoot = (...a)=>{ log.info('BOOT show', a); return show(...a); };
+    mod.hideBoot = (...a)=>{ log.info('BOOT hide'); return hide(...a); };
+  } catch {}
+}
+
+export function enableRzDebug(){
+  if(!isDebug()) return;
+  log.info('Debug RZ ATIVADO');
+  patchStore();
+  bindSelectOnce();
+  watchSelectAppearance(3000);
+  patchBoot();
+
+  // helpers no window
+  window.app = Object.assign(window.app || {}, {
+    rzDump(){
+      const st = store?.state || {};
+      const items = st.items || [];
+      const rz = st.currentRZ ?? null;
+      const same = items.filter(i=>i?.rz===rz).length;
+      console.table([{ currentRZ: rz, totalItems: items.length, itemsDoRZ: same }]);
+      return { rz, total: items.length, doRZ: same };
+    }
+  });
+
+  const unmount = mountRzOverlay(()=>window.app.rzDump());
+  if(import.meta?.hot){
+    import.meta.hot.dispose(()=>{
+      boundAbort?.abort?.();
+      unmount();
+      log.warn('HMR dispose: removendo listeners do RZ');
+    });
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,11 @@ import { initActionsPanel } from './components/ActionsPanel.js';
 import { initRzBinding } from './components/RzBinding.js';
 import { hideBoot, showBoot } from './utils/boot.js';
 
+const __debug = (
+  (typeof location !== 'undefined' && /\bdebug=1\b/.test(location.search)) ||
+  localStorage.DEBUG_RZ === '1'
+);
+
 showBoot('aguardando...');
 init();
 if (typeof window !== 'undefined') window.computeFinance = computeFinance;
@@ -17,4 +22,8 @@ initActionsPanel?.();
 Promise.resolve(startNcmQueue?.()).finally(() => hideBoot());
 // Fallback de segurança:
 setTimeout(() => hideBoot(), 2000);
+
+if (__debug) {
+  import('./debug/traceRZ.js').then(m => m.enableRzDebug?.());
+}
 

--- a/tests/rz.debug.spec.js
+++ b/tests/rz.debug.spec.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+
+describe('rzDebug toggle', ()=>{
+  it('não ativa quando DEBUG_RZ não está setado', async ()=>{
+    globalThis.location = { search: '' };
+    const mod = await import('../src/debug/logger.js');
+    expect(mod.isDebug()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add debug logger utility
- trace RZ select bindings, store mutations and boot events with optional overlay
- conditionally load tracing when `?debug=1` or `localStorage.DEBUG_RZ` is set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2c405f51c832bb5733851f64d2ea5