### PR TITLE
chore(debug): expose store on window for dev/preview diagnostics

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -545,3 +545,8 @@ async function init(){
 export { init, setCurrentRZ as selectRZ };
 
 export default store;
+
+// Expor store para debug quando existir window (dev/preview)
+if (typeof window !== 'undefined') {
+  window.store = window.store || store;
+}


### PR DESCRIPTION
## Summary
- expose store on `window.store` for easier debugging in dev/preview

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2e27024dc832babb1df9f49c108f6