### PR TITLE
feat: criar MVP de conferência no admin

### DIFF
--- a/public/admin/conferencia/app.js
+++ b/public/admin/conferencia/app.js
@@ -1,0 +1,131 @@
+import { processarPlanilha } from './excel.js';
+import { state, setRZs, setItens, setCurrentRZ } from './store/index.js';
+
+let initialized = false;
+
+function formatQuantidade(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '';
+  const formatter = Number.isInteger(value)
+    ? new Intl.NumberFormat('pt-BR')
+    : new Intl.NumberFormat('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  return formatter.format(value);
+}
+
+function formatValorUnitario(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '';
+  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+}
+
+function renderTabela(itens) {
+  const tabela = document.getElementById('tabela-itens');
+  if (!tabela) {
+    console.warn('[APP] Tabela #tabela-itens não encontrada');
+    return;
+  }
+
+  console.log('[APP] Renderizando tabela com', itens.length, 'itens');
+
+  tabela.innerHTML = '';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  ['SKU', 'Descrição', 'Qtd', 'Valor Unitário'].forEach((titulo) => {
+    const th = document.createElement('th');
+    th.textContent = titulo;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  tabela.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  itens.forEach((item) => {
+    const tr = document.createElement('tr');
+
+    const tdCodigo = document.createElement('td');
+    tdCodigo.textContent = item.codigoML ?? '';
+    tr.appendChild(tdCodigo);
+
+    const tdDescricao = document.createElement('td');
+    tdDescricao.textContent = item.descricao ?? '';
+    tr.appendChild(tdDescricao);
+
+    const tdQtd = document.createElement('td');
+    tdQtd.textContent = formatQuantidade(item.qtd);
+    tr.appendChild(tdQtd);
+
+    const tdValor = document.createElement('td');
+    tdValor.textContent = formatValorUnitario(item.valorUnit);
+    tr.appendChild(tdValor);
+
+    tbody.appendChild(tr);
+  });
+
+  tabela.appendChild(tbody);
+}
+
+async function handleFile(fileInput) {
+  if (!fileInput || typeof fileInput !== 'object' || !('files' in fileInput)) {
+    console.warn('[APP] handleFile chamado sem input de arquivo válido');
+    return;
+  }
+
+  const file = fileInput.files?.[0];
+  if (!file) {
+    console.log('[APP] Nenhum arquivo selecionado');
+    return;
+  }
+
+  console.log('[APP] Arquivo selecionado', file.name);
+
+  try {
+    const { rzs, itens } = await processarPlanilha(file);
+    console.log('[APP] Resultado do processamento', { rzs, totalItens: itens.length });
+
+    setRZs(rzs);
+    setItens(itens);
+    setCurrentRZ(rzs[0] ?? null);
+
+    renderTabela(state.itens);
+  } catch (error) {
+    console.error('[APP] Erro ao processar planilha', error);
+  } finally {
+    fileInput.value = '';
+  }
+}
+
+export function initApp() {
+  if (initialized) {
+    console.log('[APP] initApp já foi executada');
+    return;
+  }
+
+  console.log('[APP] Inicializando aplicação de conferência');
+
+  const fileInput = document.getElementById('file');
+  if (!fileInput) {
+    console.error('[APP] Input de arquivo com id "file" não encontrado');
+    return;
+  }
+
+  initialized = true;
+
+  fileInput.addEventListener('change', (event) => {
+    console.log('[APP] Evento change recebido');
+    const target = event.target;
+    if (!target || typeof target !== 'object' || !('files' in target)) {
+      console.warn('[APP] Evento change sem input de arquivo válido');
+      return;
+    }
+    handleFile(target);
+  });
+
+  console.log('[APP] Listeners registrados');
+}
+
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => initApp());
+  } else {
+    initApp();
+  }
+}

--- a/public/admin/conferencia/excel.js
+++ b/public/admin/conferencia/excel.js
@@ -1,0 +1,161 @@
+import * as XLSX from 'xlsx';
+
+const REQUIRED_COLUMNS = ['codigoML', 'descricao', 'qtd', 'valorUnit'];
+
+const COLUMN_ALIASES = {
+  codigoML: ['codigo ml', 'código ml', 'codigo', 'código', 'sku', 'mlb', 'id ml', 'item id'],
+  descricao: ['descricao', 'descrição', 'description', 'titulo', 'título', 'nome', 'produto'],
+  qtd: ['quantidade', 'qtd', 'qtde', 'qty', 'qtdade', 'quant.', 'qtd.'],
+  valorUnit: ['valor unitario', 'valor unitário', 'valor unit', 'preco unitario', 'preço unitário', 'preco', 'preço', 'unit price', 'vl unit'],
+  rz: ['rz', 'regiao', 'região', 'hub', 'centro', 'deposito', 'depósito'],
+};
+
+function normalizeText(value) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function detectarColunas(headerRow) {
+  const map = {};
+
+  headerRow.forEach((cell, index) => {
+    const normalized = normalizeText(cell);
+    if (!normalized) return;
+
+    Object.entries(COLUMN_ALIASES).forEach(([key, aliases]) => {
+      if (map[key] != null) return;
+      if (aliases.some((alias) => normalized.includes(alias))) {
+        map[key] = index;
+      }
+    });
+  });
+
+  return map;
+}
+
+function parseNumber(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  const stringValue = String(value ?? '').trim();
+  if (!stringValue) return null;
+
+  const cleaned = stringValue.replace(/\s+/g, '').replace(/[^0-9,.-]/g, '');
+  if (!cleaned) return null;
+
+  const hasComma = cleaned.includes(',');
+  const hasDot = cleaned.includes('.');
+
+  let normalized = cleaned;
+  if (hasComma && hasDot) {
+    normalized = cleaned.replace(/\./g, '').replace(/,/g, '.');
+  } else if (hasComma) {
+    normalized = cleaned.replace(/,/g, '.');
+  }
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseQuantidade(value) {
+  const parsed = parseNumber(value);
+  if (parsed == null) return 0;
+  return parsed;
+}
+
+function parseValorUnit(value) {
+  const parsed = parseNumber(value);
+  if (parsed == null) return 0;
+  return parsed;
+}
+
+function normalizarItem(row, colunas) {
+  const getValue = (key) => {
+    const index = colunas[key];
+    if (index == null) return '';
+    return row[index] ?? '';
+  };
+
+  const codigoML = String(getValue('codigoML')).trim();
+  const descricao = String(getValue('descricao')).trim();
+  const qtd = parseQuantidade(getValue('qtd'));
+  const valorUnit = parseValorUnit(getValue('valorUnit'));
+  const rzRaw = colunas.rz != null ? row[colunas.rz] : null;
+  const rz = typeof rzRaw === 'string' ? rzRaw.trim() : rzRaw ?? null;
+
+  if (!codigoML && !descricao) return null;
+
+  return {
+    codigoML,
+    descricao,
+    qtd,
+    valorUnit,
+    ...(rz ? { rz } : {}),
+  };
+}
+
+function validarColunas(colunas) {
+  const faltantes = REQUIRED_COLUMNS.filter((col) => colunas[col] == null);
+  if (faltantes.length) {
+    console.warn('[EXCEL] Colunas obrigatórias não encontradas:', faltantes);
+  }
+}
+
+export async function processarPlanilha(file) {
+  console.log('[EXCEL] Iniciando processamento', file?.name ?? 'arquivo indefinido');
+  if (!file) {
+    return { rzs: [], itens: [] };
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  console.log('[EXCEL] Arquivo carregado, convertendo planilha');
+  const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+  const sheetName = workbook.SheetNames?.[0];
+  if (!sheetName) {
+    console.warn('[EXCEL] Nenhuma aba encontrada no arquivo');
+    return { rzs: [], itens: [] };
+  }
+
+  const worksheet = workbook.Sheets[sheetName];
+  const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
+  if (!rows.length) {
+    console.warn('[EXCEL] Planilha vazia');
+    return { rzs: [], itens: [] };
+  }
+
+  const headerIndex = rows.findIndex((row) => Array.isArray(row) && row.some((cell) => String(cell).trim() !== ''));
+  const headerRow = headerIndex >= 0 ? rows[headerIndex] : rows[0];
+  const dataRows = headerIndex >= 0 ? rows.slice(headerIndex + 1) : rows.slice(1);
+
+  const colunas = detectarColunas(headerRow);
+  validarColunas(colunas);
+
+  const itens = [];
+  dataRows.forEach((row, rowIndex) => {
+    if (!Array.isArray(row)) return;
+    const item = normalizarItem(row, colunas);
+    if (item) {
+      itens.push(item);
+    } else {
+      console.log('[EXCEL] Linha ignorada', headerIndex + 1 + rowIndex + 1, row);
+    }
+  });
+
+  const rzs = Array.from(
+    new Set(
+      itens
+        .map((item) => item.rz)
+        .filter((value) => value != null && value !== '')
+        .map((value) => (typeof value === 'string' ? value.trim() : value)),
+    ),
+  );
+
+  console.log('[EXCEL] Processamento concluído', { totalItens: itens.length, rzs });
+
+  return { rzs, itens };
+}

--- a/public/admin/conferencia/store/index.js
+++ b/public/admin/conferencia/store/index.js
@@ -1,0 +1,52 @@
+const state = {
+  currentRZ: null,
+  rzs: [],
+  itens: [],
+};
+
+function normalizeArray(value) {
+  if (!Array.isArray(value)) return [];
+
+  const resultado = [];
+
+  value.forEach((item) => {
+    if (item == null) return;
+    const normalizado = typeof item === 'string' ? item.trim() : item;
+    if (normalizado === '') return;
+    if (!resultado.includes(normalizado)) {
+      resultado.push(normalizado);
+    }
+  });
+
+  return resultado;
+}
+
+export function setRZs(rzs) {
+  state.rzs = normalizeArray(rzs);
+  console.log('[STORE] setRZs', state.rzs);
+
+  if (!state.rzs.includes(state.currentRZ)) {
+    state.currentRZ = state.rzs[0] ?? null;
+    if (state.currentRZ != null) {
+      console.log('[STORE] currentRZ ajustado', state.currentRZ);
+    }
+  }
+}
+
+export function setItens(itens) {
+  state.itens = Array.isArray(itens) ? [...itens] : [];
+  console.log('[STORE] setItens', state.itens.length);
+}
+
+export function setCurrentRZ(rz) {
+  const normalizado = typeof rz === 'string' ? rz.trim() : rz;
+  state.currentRZ = normalizado ?? null;
+  console.log('[STORE] setCurrentRZ', state.currentRZ);
+
+  if (state.currentRZ != null && !state.rzs.includes(state.currentRZ)) {
+    state.rzs = normalizeArray([state.currentRZ, ...state.rzs]);
+    console.log('[STORE] currentRZ adicionado à lista de RZs', state.rzs);
+  }
+}
+
+export { state };


### PR DESCRIPTION
## Summary
- adiciona store mínimo com estado de RZs, itens e seleção atual no admin
- implementa processamento de planilha com detecção das colunas essenciais e normalização de dados
- cria app simples que lê o arquivo enviado, atualiza o store e renderiza tabela com os itens

## Testing
- npm test *(fails: tests/boot.spec.js espera `on` no mock de `src/store/index.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e7caa58c832b80717c6fb58dcd13