### PR TITLE
Add admin conference HTML bootstrap

### DIFF
--- a/public/admin/conferencia/index.html
+++ b/public/admin/conferencia/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conferência de Lotes — MVP</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        background: #f5f6f8;
+        color: #1f2933;
+      }
+
+      main {
+        margin: 0 auto;
+        padding: 32px 16px 48px;
+        max-width: 960px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      h1,
+      h2 {
+        margin: 0;
+      }
+
+      .card {
+        background: #fff;
+        border-radius: 12px;
+        border: 1px solid #d7dce1;
+        box-shadow: 0 8px 32px rgba(15, 23, 42, 0.08);
+      }
+
+      .card-header {
+        padding: 20px 24px 0;
+      }
+
+      .card-body {
+        padding: 20px 24px 24px;
+        display: grid;
+        gap: 16px;
+      }
+
+      label {
+        font-size: 0.85rem;
+        font-weight: 600;
+        display: block;
+        margin-bottom: 4px;
+      }
+
+      input[type="file"],
+      select {
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid #c7ccd4;
+        border-radius: 8px;
+        font-size: 1rem;
+        background: #fff;
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        padding: 12px 16px;
+        border-bottom: 1px solid #e2e6ea;
+        text-align: left;
+        font-size: 0.95rem;
+      }
+
+      th {
+        background: #f1f4f8;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      #file-name {
+        font-size: 0.9rem;
+        color: #3e4c59;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Conferência de Lotes (MVP)</h1>
+      </header>
+
+      <section id="card-importacao" class="card">
+        <div class="card-header">
+          <h2>Importação &amp; Seleção</h2>
+        </div>
+        <div class="card-body">
+          <div>
+            <label for="file">Planilha (.xlsx)</label>
+            <input type="file" id="file" accept=".xlsx" />
+            <div id="file-name"></div>
+          </div>
+          <div>
+            <label for="select-rz">RZ</label>
+            <select id="select-rz"></select>
+          </div>
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>Itens importados</h2>
+        </div>
+        <div class="card-body">
+          <div class="table-wrap">
+            <table id="tabela-itens"></table>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "xlsx": "https://cdn.jsdelivr.net/npm/xlsx@0.18.5/+esm"
+        }
+      }
+    </script>
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `public/admin/conferencia/index.html` so the MVP assets are loaded from the expected location
- include the required DOM skeleton (`#file`, `#select-rz`, `#card-importacao`, `#tabela-itens`) and an import map for `xlsx`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e9e888b8832b8a28c2bd3719616f